### PR TITLE
Add multi-arch Docker publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git/
+.github/
 .githooks/
 .pytest_cache/
 .mypy_cache/
@@ -7,9 +8,14 @@
 venv/
 __pycache__/
 *.py[cod]
+.coverage
+htmlcov/
 .DS_Store
 .env
+.env.*
 trace_logs/
 models/*
 !models/.gitkeep
 !models/README.md
+*.log
+docker-bake.hcl

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,92 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to publish, for example v0.1.3"
+        required: true
+        type: string
+      publish_latest:
+        description: "Also publish marcellm01/tinysearch:latest"
+        required: true
+        default: true
+        type: boolean
+
+env:
+  IMAGE_NAME: marcellm01/tinysearch
+
+jobs:
+  docker:
+    name: Build and publish multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set image version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            echo "value=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set image tags
+        id: tags
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_VERSION: ${{ steps.version.outputs.value }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_LATEST: ${{ github.event.inputs.publish_latest }}
+        run: |
+          {
+            echo "value<<EOF"
+            echo "${IMAGE_NAME}:${IMAGE_VERSION}"
+            if [ "${EVENT_NAME}" != "workflow_dispatch" ] || [ "${PUBLISH_LATEST}" = "true" ]; then
+              echo "${IMAGE_NAME}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: mcp
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            TINYSEARCH_VERSION=${{ steps.version.outputs.value }}
+          tags: ${{ steps.tags.outputs.value }}
+          labels: |
+            org.opencontainers.image.title=TinySearch MCP
+            org.opencontainers.image.description=TinySearch MCP stdio and HTTP server
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.version.outputs.value }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that builds and pushes `marcellm01/tinysearch` for `linux/amd64` and `linux/arm64`
- publish on version tags, published GitHub Releases, and manual workflow runs
- keep Docker build contexts smaller with a few extra `.dockerignore` entries

## Validation

- `git diff --check`
- parsed `.github/workflows/docker-publish.yml` as YAML

Closes #1