### PR TITLE
Add SearXNG search backend with DuckDuckGo fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # TinySearch
 
-> [!WARNING]
-> TinySearch is temporarily affected by DuckDuckGo limiting automated searches from some environments. We are switching the search layer to SearxNG. Please give us a few days and we will be back with a more reliable setup.
+> [!NOTE]
+> TinySearch now defaults to a SearXNG-compatible search backend, with the
+> existing DuckDuckGo HTML scraper kept as a configurable fallback. The bundled
+> `compose.yaml` ships a local SearXNG service so the stack works out of the
+> box. See [Search backends](#search-backends) for configuration.
 
 <p align="center">
   <img src="assets/tinysearch_logo.png" alt="TinySearch" width="240" />
@@ -75,7 +78,7 @@ search backend.
 flowchart TB
     subgraph Row1["Search and choose pages"]
         direction LR
-        A[User query] --> B[DuckDuckGo HTML search]
+        A[User query] --> B[Web search<br/>SearXNG default, DuckDuckGo fallback]
         B --> C[Filter HTTP results<br/>build title URL domain snippet docs]
         C --> D[Rank search docs<br/>dense + BM25 weighted RRF]
     end
@@ -291,6 +294,7 @@ You can also set `embedding_model` to a custom Hugging Face ONNX repo id. Set
 Key settings:
 
 - Search: `search_top_k`, `search_rrf_cutoff`, `search_dense_weight`, `search_max_results_to_keep`, `blocked_domains`
+- Search backend: `search_backend`, `search_backend_url`, `search_engines`, `search_region`, `search_backend_fallback`
 - Chunks: `chunk_rrf_cutoff`, `chunk_dense_weight`, `chunk_max_results_to_keep`
 - Crawl: `crawl_max_chunk_tokens`, `crawl_overlap_tokens`, `max_concurrent_crawls`
 - Embeddings: `embedding_backend`, `embedding_model`, `embedding_openai_env_file`, `max_concurrent_embedding_calls`
@@ -312,6 +316,88 @@ OPENAI_EMBEDDING_MODEL=
 
 The research pipeline requires dense embeddings. It raises if
 `search_dense_weight` or `chunk_dense_weight` is set to `0`.
+
+## Search backends
+
+TinySearch supports two web-search backends and selects between them from
+config. The defaults aim at the bundled compose setup: SearXNG runs as a
+sidecar, with the DuckDuckGo HTML scraper kept as an automatic fallback.
+
+Available values for `search_backend`:
+
+- `"searxng"` (default): query a SearXNG-compatible JSON endpoint. If the call
+  fails and `search_backend_fallback` is `true`, TinySearch falls back to
+  DuckDuckGo. With `search_backend_fallback: false` the SearXNG error surfaces.
+- `"duckduckgo"`: skip SearXNG entirely and use the existing DuckDuckGo HTML
+  scraper. This is the escape hatch that preserves pre-0.2 behavior.
+- `"auto"`: try SearXNG, then DuckDuckGo on any backend failure (fallback
+  is implied regardless of `search_backend_fallback`).
+
+A backend "failure" means a real backend error: network/timeout, non-200 HTTP
+response, a non-JSON SearXNG body, or a DuckDuckGo CAPTCHA / 403. A legitimate
+empty result set is **not** a failure and does not trigger fallback.
+
+Minimal config example:
+
+```json
+{
+  "search_backend": "searxng",
+  "search_backend_url": "http://searxng:8080/search",
+  "search_engines": ["google", "bing"],
+  "search_region": "us-en",
+  "search_backend_fallback": true
+}
+```
+
+### SearXNG JSON output is required
+
+SearXNG ships with the JSON output format **disabled** by default. The bundled
+`searxng/settings.yml` enables it via:
+
+```yaml
+search:
+  formats:
+    - html
+    - json
+```
+
+If TinySearch reports `SearchBackendUnavailable: SearXNG did not return JSON`,
+your SearXNG instance is returning HTML — add `json` to `search.formats` and
+restart it.
+
+### Environment overrides
+
+- `SEARXNG_URL`: overrides `search_backend_url` for the running process. Useful
+  in Docker so the same image can point at different SearXNG endpoints without
+  rebuilding `research_config.json`.
+
+### Compose setup
+
+The bundled `compose.yaml` starts a `searxng` service alongside `mcp` (and
+optionally `fastapi`). The `mcp` and `fastapi` services reach SearXNG at
+`http://searxng:8080/search` over the internal compose network, and have
+`SEARXNG_URL` set automatically.
+
+```bash
+docker compose up
+```
+
+A minimal `searxng/settings.yml` is committed at the repo root. Override
+`server.secret_key` before exposing the SearXNG instance beyond localhost.
+
+### Single-container / from-source
+
+When you run TinySearch standalone (e.g. `docker run marcellm01/tinysearch:latest`
+or `python servers/mcp_server.py`), there is no local SearXNG. With the default
+config (`search_backend: "searxng"`, `search_backend_fallback: true`) the
+SearXNG call fails fast on the short connect timeout and TinySearch
+transparently falls back to DuckDuckGo.
+
+To keep the pre-0.2 behavior with no SearXNG involvement, set:
+
+```json
+{ "search_backend": "duckduckgo" }
+```
 
 ## When not to use TinySearch
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,9 @@ services:
       MCP_TRANSPORT: streamable-http
       MCP_HOST: 0.0.0.0
       MCP_PORT: 8000
+      SEARXNG_URL: http://searxng:8080/search
+    depends_on:
+      - searxng
 
   fastapi:
     build:
@@ -37,6 +40,18 @@ services:
     environment:
       TINYSEARCH_MODELS_DIR: /data/models
       TINYSEARCH_CONFIG_PATH: /config/research_config.json
+      SEARXNG_URL: http://searxng:8080/search
+    depends_on:
+      - searxng
+
+  searxng:
+    image: searxng/searxng
+    volumes:
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+    environment:
+      INSTANCE_NAME: tinysearch-searxng
+      BASE_URL: http://localhost:8080/
+    restart: unless-stopped
 
 volumes:
   tinysearch-models:

--- a/configs/research_config.json
+++ b/configs/research_config.json
@@ -30,5 +30,10 @@
   "dense_document_prefix": "",
   "dense_document_embed_batch_size": 32,
   "blocked_domains": [],
+  "search_backend": "searxng",
+  "search_backend_url": "http://searxng:8080/search",
+  "search_engines": [],
+  "search_region": "",
+  "search_backend_fallback": true,
   "trace_path": "trace_logs/agentic_trace.json"
 }

--- a/pipelines/agentic_research.py
+++ b/pipelines/agentic_research.py
@@ -45,6 +45,7 @@ from services.research_config_service import (
 from services.site_crawl_service import crawl
 from services.text_chunking_service import chunk_text, truncate_text_to_max_tokens
 from services.web_search_service import (
+    SearchBackendError,
     SearchResult,
     filter_blocked_search_results,
     search,
@@ -421,7 +422,14 @@ async def agentic_run(
             await emit("start", query=query)
             await emit("search_start", query=query, search_top_k=search_top_k)
             _agentic_log(f"search start top_k={search_top_k}")
-            results = [result for result in search_fn(query, max(1, search_top_k)) if _is_http_url(result.url)]
+            try:
+                raw_results = search_fn(query, max(1, search_top_k))
+            except SearchBackendError as exc:
+                _agentic_log(f"search backend error: {exc}")
+                await emit("search_backend_error", error=str(exc))
+                prompt = _format_results_prompt(question=query, results=[])
+                return finish("search_backend_error", prompt, [])
+            results = [result for result in raw_results if _is_http_url(result.url)]
             results = filter_blocked_search_results(results, blocked_domains or [])
             _agentic_log(f"search done results={len(results)}")
             trace["web_search"] = [asdict(result) for result in results]

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -1,0 +1,15 @@
+use_default_settings: true
+
+# SearXNG ships with JSON output disabled by default. TinySearch's SearXNG
+# backend calls the endpoint with format=json, so we must enable it here.
+search:
+  formats:
+    - html
+    - json
+
+server:
+  # Override this in production. The default value below only exists so the
+  # bundled compose setup boots without requiring extra steps for local dev.
+  secret_key: "tinysearch-local-dev-only-change-me"
+  limiter: false
+  image_proxy: false

--- a/servers/mcp_server.py
+++ b/servers/mcp_server.py
@@ -132,7 +132,8 @@ Pass the user's question as-is in query. Do not rewrite, correct spelling,
 expand abbreviations, add dates, add missing context, simplify, translate, or
 otherwise improve the user's wording before calling the tool.
 
-The tool searches DuckDuckGo, ranks search results with dense embeddings and
+The tool runs a web search through the configured backend (SearXNG by default,
+with a DuckDuckGo fallback), ranks search results with dense embeddings and
 BM25 using reciprocal rank fusion, crawls kept pages, ranks page chunks, and
 returns a prompt in the answer field. The caller's LLM should answer from that
 prompt and cite source URLs from the result blocks.

--- a/services/research_config_service.py
+++ b/services/research_config_service.py
@@ -13,7 +13,7 @@ from services.embedding_service import (
     resolve_local_embedding_model_spec,
     resolve_embedding_tokenizer_name,
 )
-from services.web_search_service import normalize_domain
+from services.web_search_service import ALLOWED_SEARCH_BACKENDS, DEFAULT_SEARXNG_URL, normalize_domain
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -51,6 +51,11 @@ DEFAULT_RESEARCH_CONFIG: dict[str, Any] = {
     "dense_document_prefix": "",
     "dense_document_embed_batch_size": 32,
     "blocked_domains": [],
+    "search_backend": "searxng",
+    "search_backend_url": DEFAULT_SEARXNG_URL,
+    "search_engines": [],
+    "search_region": "",
+    "search_backend_fallback": True,
     "trace_path": "trace_logs/agentic_trace.json",
 }
 
@@ -117,6 +122,48 @@ def _coerce_config(raw: dict[str, Any]) -> dict[str, Any]:
             if normalized
         )
     )
+
+    backend = str(config.get("search_backend") or "searxng").strip().lower()
+    if backend not in ALLOWED_SEARCH_BACKENDS:
+        raise ValueError(
+            "research config search_backend must be one of "
+            f"{sorted(ALLOWED_SEARCH_BACKENDS)}"
+        )
+    config["search_backend"] = backend
+
+    env_searxng_url = os.environ.get("SEARXNG_URL", "").strip()
+    if env_searxng_url:
+        config["search_backend_url"] = env_searxng_url
+    else:
+        config["search_backend_url"] = str(
+            config.get("search_backend_url") or DEFAULT_SEARXNG_URL
+        ).strip() or DEFAULT_SEARXNG_URL
+
+    engines_raw = config.get("search_engines")
+    if engines_raw is None or engines_raw == "":
+        engines_list: list[str] = []
+    elif isinstance(engines_raw, str):
+        engines_list = [part.strip() for part in engines_raw.split(",") if part.strip()]
+    elif isinstance(engines_raw, list):
+        engines_list = [
+            str(item).strip() for item in engines_raw if str(item).strip()
+        ]
+    else:
+        raise ValueError(
+            "research config search_engines must be a list or comma-separated string"
+        )
+    config["search_engines"] = engines_list
+
+    region_raw = config.get("search_region")
+    if not region_raw:
+        region_raw = config.get("search_country")
+    config["search_region"] = str(region_raw or "").strip()
+    config.pop("search_country", None)
+
+    config["search_backend_fallback"] = bool(
+        config.get("search_backend_fallback", True)
+    )
+
     return config
 
 

--- a/services/web_search_service.py
+++ b/services/web_search_service.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import asyncio
 import html as _html
+import json
 import re
+import socket
 import sys
-from collections.abc import Iterable
+import urllib.error
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
-from urllib.parse import parse_qs, quote_plus, unquote, urlparse
+from urllib.parse import parse_qs, quote_plus, unquote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 
@@ -34,6 +39,33 @@ class SearchResult:
     title: str
     url: str
     text: str
+
+
+class SearchBackendError(Exception):
+    """Base error raised when a search backend fails to produce results."""
+
+
+class SearchBackendUnavailable(SearchBackendError):
+    """Network, timeout, non-200, or non-JSON response from a backend."""
+
+
+class SearchBackendBlocked(SearchBackendError):
+    """Backend rejected the request (HTTP 403/429 or CAPTCHA/challenge page)."""
+
+
+ALLOWED_SEARCH_BACKENDS: frozenset[str] = frozenset({"searxng", "duckduckgo", "auto"})
+DEFAULT_SEARXNG_URL = "http://searxng:8080/search"
+_DEFAULT_DDG_TIMEOUT = 20.0
+_DEFAULT_SEARXNG_TIMEOUT = 8.0
+
+_DDG_CHALLENGE_MARKERS: tuple[str, ...] = (
+    "anomaly-modal",
+    "anomaly_modal",
+    "captcha-container",
+    "challenge-form",
+    "automated queries",
+    "unusual traffic",
+)
 
 
 def normalize_domain(value: str) -> str:
@@ -89,7 +121,7 @@ def _decode_duckduckgo_href(href: str) -> str:
     return href
 
 
-def _http_get(url: str) -> str:
+def _http_get(url: str, *, timeout: float = _DEFAULT_DDG_TIMEOUT) -> str:
     req = Request(
         url,
         headers={
@@ -97,10 +129,15 @@ def _http_get(url: str) -> str:
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         },
     )
-    with urlopen(req, timeout=20) as resp:
+    with urlopen(req, timeout=timeout) as resp:
         raw = resp.read()
         charset = getattr(resp.headers, "get_content_charset", lambda default=None: None)("utf-8") or "utf-8"
     return raw.decode(charset, errors="replace")
+
+
+def _looks_like_ddg_challenge(html: str) -> bool:
+    lowered = html.lower()
+    return any(marker in lowered for marker in _DDG_CHALLENGE_MARKERS)
 
 
 async def crawl(url: str) -> dict:
@@ -120,17 +157,28 @@ async def crawl(url: str) -> dict:
     return {"url": url, "markdown": markdown, "html": html, "links": links}
 
 
-def search(query: str, limit: int = 10) -> list[SearchResult]:
-    """
-    Query DuckDuckGo's HTML endpoint and return the top results.
-
-    Returns items shaped like:
-      Title:
-      URL:
-      Text:
-    """
+def _duckduckgo_search(query: str, limit: int) -> list[SearchResult]:
+    """Query DuckDuckGo's HTML endpoint and return the top results."""
     url = f"https://html.duckduckgo.com/html/?q={quote_plus(query)}"
-    html = _http_get(url)
+    try:
+        html = _http_get(url, timeout=_DEFAULT_DDG_TIMEOUT)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (403, 429):
+            raise SearchBackendBlocked(
+                f"DuckDuckGo refused the request (HTTP {exc.code})"
+            ) from exc
+        raise SearchBackendUnavailable(
+            f"DuckDuckGo returned HTTP {exc.code}"
+        ) from exc
+    except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as exc:
+        raise SearchBackendUnavailable(
+            f"DuckDuckGo unreachable: {exc}"
+        ) from exc
+
+    if _looks_like_ddg_challenge(html):
+        raise SearchBackendBlocked(
+            "DuckDuckGo returned a CAPTCHA/challenge page"
+        )
 
     # DDG HTML results use anchors like: <a class="result__a" href="...">Title</a>
     matches = re.findall(
@@ -160,6 +208,165 @@ def search(query: str, limit: int = 10) -> list[SearchResult]:
             break
 
     return out
+
+
+def _normalize_engines(engines: Any) -> str:
+    if engines is None:
+        return ""
+    if isinstance(engines, str):
+        parts = [part.strip() for part in engines.split(",")]
+    elif isinstance(engines, Sequence):
+        parts = [str(part).strip() for part in engines]
+    else:
+        parts = [str(engines).strip()]
+    return ",".join(part for part in parts if part)
+
+
+def _searxng_search(
+    query: str,
+    limit: int,
+    *,
+    url: str,
+    engines: Any = None,
+    region: str | None = None,
+    timeout: float = _DEFAULT_SEARXNG_TIMEOUT,
+) -> list[SearchResult]:
+    """Query a SearXNG-compatible JSON endpoint."""
+    if not url or not url.strip():
+        raise SearchBackendUnavailable("SearXNG search_backend_url is empty")
+
+    params: list[tuple[str, str]] = [
+        ("q", query),
+        ("format", "json"),
+        ("pageno", "1"),
+    ]
+    engines_str = _normalize_engines(engines)
+    if engines_str:
+        params.append(("engines", engines_str))
+    if region:
+        params.append(("language", str(region)))
+
+    full_url = f"{url}?{urlencode(params)}"
+    req = Request(
+        full_url,
+        headers={
+            "User-Agent": "TinySearch/0.1 (+searxng)",
+            "Accept": "application/json",
+        },
+    )
+
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            content_type = resp.headers.get("Content-Type", "") or ""
+    except urllib.error.HTTPError as exc:
+        raise SearchBackendUnavailable(
+            f"SearXNG returned HTTP {exc.code} from {url}"
+        ) from exc
+    except (urllib.error.URLError, socket.timeout, TimeoutError, OSError) as exc:
+        raise SearchBackendUnavailable(
+            f"SearXNG unreachable at {url}: {exc}"
+        ) from exc
+
+    text = raw.decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SearchBackendUnavailable(
+            "SearXNG did not return JSON "
+            f"(content-type={content_type!r}). "
+            "Enable JSON output by adding 'json' to search.formats in searxng settings.yml."
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise SearchBackendUnavailable("SearXNG JSON payload was not an object")
+
+    raw_results = payload.get("results") or []
+    if not isinstance(raw_results, list):
+        raise SearchBackendUnavailable("SearXNG 'results' field was not a list")
+
+    out: list[SearchResult] = []
+    for item in raw_results:
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or "").strip()
+        target = str(item.get("url") or "").strip()
+        text_field = str(item.get("content") or "").strip()
+        if not title or not target:
+            continue
+        out.append(
+            SearchResult(
+                result_id=len(out) + 1,
+                title=title,
+                url=target,
+                text=text_field,
+            )
+        )
+        if len(out) >= limit:
+            break
+
+    return out
+
+
+def _load_search_config() -> dict[str, Any]:
+    # Lazy import to avoid a circular dependency with research_config_service.
+    from services.research_config_service import load_research_config
+
+    return load_research_config()
+
+
+def _dispatch_search(
+    query: str,
+    limit: int,
+    *,
+    config: dict[str, Any],
+) -> list[SearchResult]:
+    backend = str(config.get("search_backend") or "searxng").strip().lower()
+    if backend not in ALLOWED_SEARCH_BACKENDS:
+        backend = "searxng"
+    url = str(config.get("search_backend_url") or DEFAULT_SEARXNG_URL)
+    engines = config.get("search_engines")
+    region = (
+        config.get("search_region")
+        or config.get("search_country")
+        or ""
+    )
+    fallback_enabled = bool(config.get("search_backend_fallback", True))
+
+    if backend == "duckduckgo":
+        return _duckduckgo_search(query, limit)
+
+    if backend == "auto":
+        try:
+            return _searxng_search(
+                query, limit, url=url, engines=engines, region=str(region) or None
+            )
+        except SearchBackendError:
+            return _duckduckgo_search(query, limit)
+
+    # backend == "searxng"
+    try:
+        return _searxng_search(
+            query, limit, url=url, engines=engines, region=str(region) or None
+        )
+    except SearchBackendError:
+        if fallback_enabled:
+            return _duckduckgo_search(query, limit)
+        raise
+
+
+def search(query: str, limit: int = 10) -> list[SearchResult]:
+    """
+    Run a web search using the configured backend.
+
+    Returns items shaped like:
+      Title:
+      URL:
+      Text:
+    """
+    config = _load_search_config()
+    return _dispatch_search(query, limit, config=config)
+
 
 def search_to_markdown(search_results: list[SearchResult]) -> str:
     markdown = ""

--- a/tests/test_agentic_research_pipeline.py
+++ b/tests/test_agentic_research_pipeline.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import json
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from pipelines.agentic_research import agentic_run
-from services.web_search_service import SearchResult
+from services.web_search_service import (
+    SearchBackendUnavailable,
+    SearchResult,
+)
 
 
 def _fake_search(query: str, limit: int) -> list[SearchResult]:
@@ -251,6 +257,27 @@ class AgenticResearchPipelineTests(unittest.IsolatedAsyncioTestCase):
                 search_fn=_fake_search,
                 crawl_fn=_fake_crawl,
             )
+
+    async def test_pipeline_reports_distinct_status_when_backend_fails(self) -> None:
+        def failing_search(query: str, limit: int) -> list[SearchResult]:
+            raise SearchBackendUnavailable("all backends down")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "trace.json"
+            result = await agentic_run(
+                "python async search",
+                search_top_k=1,
+                search_max_results_to_keep=1,
+                embedder=_fake_embedder,
+                search_fn=failing_search,
+                crawl_fn=_fake_crawl,
+                trace_path=str(trace_path),
+            )
+
+            self.assertIn("QUESTION", result.answer)
+            self.assertNotIn("RESULT 1", result.answer)
+            trace = json.loads(trace_path.read_text(encoding="utf-8"))
+            self.assertEqual(trace["status"], "search_backend_error")
 
     async def test_pipeline_propagates_embedding_failures(self) -> None:
         call_count = 0

--- a/tests/test_web_search_service.py
+++ b/tests/test_web_search_service.py
@@ -1,13 +1,87 @@
 from __future__ import annotations
 
+import json
+import socket
 import unittest
+import urllib.error
+from typing import Any
+from unittest.mock import patch
 
+from services import web_search_service
 from services.web_search_service import (
+    DEFAULT_SEARXNG_URL,
+    SearchBackendBlocked,
+    SearchBackendError,
+    SearchBackendUnavailable,
     SearchResult,
+    _dispatch_search,
+    _duckduckgo_search,
+    _searxng_search,
     filter_blocked_search_results,
     is_blocked_domain,
     normalize_domain,
+    search,
 )
+
+
+class _FakeHeaders:
+    def __init__(self, content_type: str = "", charset: str | None = "utf-8") -> None:
+        self._content_type = content_type
+        self._charset = charset
+
+    def get(self, key: str, default: str = "") -> str:
+        if key.lower() == "content-type":
+            return self._content_type
+        return default
+
+    def get_content_charset(self, default: str | None = None) -> str | None:
+        return self._charset if self._charset is not None else default
+
+
+class _FakeUrlopenResponse:
+    def __init__(
+        self,
+        body: bytes | str,
+        *,
+        content_type: str = "application/json",
+        charset: str = "utf-8",
+    ) -> None:
+        if isinstance(body, str):
+            body = body.encode(charset)
+        self._body = body
+        self._headers = _FakeHeaders(content_type=content_type, charset=charset)
+
+    def __enter__(self) -> "_FakeUrlopenResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+    @property
+    def headers(self) -> _FakeHeaders:
+        return self._headers
+
+
+def _make_urlopen_returning(
+    body: bytes | str,
+    *,
+    content_type: str = "application/json",
+    charset: str = "utf-8",
+):
+    def fake(req: Any, timeout: Any = None) -> _FakeUrlopenResponse:
+        return _FakeUrlopenResponse(body, content_type=content_type, charset=charset)
+
+    return fake
+
+
+def _make_urlopen_raising(exc: BaseException):
+    def fake(req: Any, timeout: Any = None) -> Any:
+        raise exc
+
+    return fake
 
 
 class BlockedDomainTests(unittest.TestCase):
@@ -45,6 +119,365 @@ class BlockedDomainTests(unittest.TestCase):
         filtered = filter_blocked_search_results(results, ["blocked.example"])
 
         self.assertEqual([result.title for result in filtered], ["Allowed"])
+
+
+class SearXNGBackendTests(unittest.TestCase):
+    def test_searxng_json_response_maps_to_search_results(self) -> None:
+        payload = {
+            "results": [
+                {
+                    "title": "Async tasks in Python",
+                    "url": "https://example.com/python",
+                    "content": "Coroutines and tasks.",
+                },
+                {
+                    "title": "Bread baking",
+                    "url": "https://example.com/bread",
+                    "content": "Flour and yeast.",
+                },
+            ]
+        }
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(json.dumps(payload)),
+        ):
+            results = _searxng_search(
+                "python async", 5, url="http://searxng:8080/search"
+            )
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].title, "Async tasks in Python")
+        self.assertEqual(results[0].url, "https://example.com/python")
+        self.assertEqual(results[0].text, "Coroutines and tasks.")
+        self.assertEqual(results[0].result_id, 1)
+        self.assertEqual(results[1].result_id, 2)
+
+    def test_searxng_respects_limit(self) -> None:
+        payload = {
+            "results": [
+                {"title": f"r{i}", "url": f"https://example.com/{i}", "content": ""}
+                for i in range(10)
+            ]
+        }
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(json.dumps(payload)),
+        ):
+            results = _searxng_search("q", 3, url="http://searxng:8080/search")
+
+        self.assertEqual(len(results), 3)
+
+    def test_searxng_html_response_raises_unavailable_with_actionable_message(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(
+                "<html><body>not json</body></html>", content_type="text/html"
+            ),
+        ):
+            with self.assertRaises(SearchBackendUnavailable) as cm:
+                _searxng_search("q", 5, url="http://searxng:8080/search")
+
+        message = str(cm.exception).lower()
+        self.assertIn("json", message)
+        self.assertIn("formats", message)
+
+    def test_searxng_network_error_raises_unavailable(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_raising(urllib.error.URLError("connection refused")),
+        ):
+            with self.assertRaises(SearchBackendUnavailable):
+                _searxng_search("q", 5, url="http://searxng:8080/search")
+
+    def test_searxng_http_500_raises_unavailable(self) -> None:
+        http_error = urllib.error.HTTPError(
+            "http://searxng:8080/search", 500, "Server Error", {}, None
+        )
+        with patch.object(
+            web_search_service, "urlopen", new=_make_urlopen_raising(http_error)
+        ):
+            with self.assertRaises(SearchBackendUnavailable):
+                _searxng_search("q", 5, url="http://searxng:8080/search")
+
+    def test_searxng_timeout_raises_unavailable(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_raising(socket.timeout("timed out")),
+        ):
+            with self.assertRaises(SearchBackendUnavailable):
+                _searxng_search("q", 5, url="http://searxng:8080/search")
+
+    def test_searxng_empty_results_list_is_not_an_error(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(json.dumps({"results": []})),
+        ):
+            results = _searxng_search("q", 5, url="http://searxng:8080/search")
+        self.assertEqual(results, [])
+
+
+class DuckDuckGoBackendTests(unittest.TestCase):
+    _RESULT_HTML = (
+        "<html><body>"
+        '<a class="result__a" href="https://example.com/page">Example Title</a>'
+        '<a class="result__snippet">Example snippet.</a>'
+        "</body></html>"
+    )
+
+    def test_ddg_returns_results_on_valid_html(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(self._RESULT_HTML, content_type="text/html"),
+        ):
+            results = _duckduckgo_search("anything", 5)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].title, "Example Title")
+        self.assertEqual(results[0].url, "https://example.com/page")
+        self.assertEqual(results[0].text, "Example snippet.")
+
+    def test_ddg_valid_page_without_matches_returns_empty(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(
+                "<html><body><p>No results for your query.</p></body></html>",
+                content_type="text/html",
+            ),
+        ):
+            results = _duckduckgo_search("anything", 5)
+        self.assertEqual(results, [])
+
+    def test_ddg_403_raises_blocked(self) -> None:
+        http_error = urllib.error.HTTPError(
+            "https://html.duckduckgo.com/html/", 403, "Forbidden", {}, None
+        )
+        with patch.object(
+            web_search_service, "urlopen", new=_make_urlopen_raising(http_error)
+        ):
+            with self.assertRaises(SearchBackendBlocked):
+                _duckduckgo_search("anything", 5)
+
+    def test_ddg_429_raises_blocked(self) -> None:
+        http_error = urllib.error.HTTPError(
+            "https://html.duckduckgo.com/html/", 429, "Too Many", {}, None
+        )
+        with patch.object(
+            web_search_service, "urlopen", new=_make_urlopen_raising(http_error)
+        ):
+            with self.assertRaises(SearchBackendBlocked):
+                _duckduckgo_search("anything", 5)
+
+    def test_ddg_challenge_page_raises_blocked(self) -> None:
+        challenge_html = (
+            "<html><body><div class='anomaly-modal'>"
+            "Please verify you are human</div></body></html>"
+        )
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_returning(challenge_html, content_type="text/html"),
+        ):
+            with self.assertRaises(SearchBackendBlocked):
+                _duckduckgo_search("anything", 5)
+
+    def test_ddg_network_error_raises_unavailable(self) -> None:
+        with patch.object(
+            web_search_service,
+            "urlopen",
+            new=_make_urlopen_raising(urllib.error.URLError("no network")),
+        ):
+            with self.assertRaises(SearchBackendUnavailable):
+                _duckduckgo_search("anything", 5)
+
+
+class DispatcherTests(unittest.TestCase):
+    _CONFIG_BASE: dict[str, Any] = {
+        "search_backend": "searxng",
+        "search_backend_url": "http://searxng:8080/search",
+        "search_engines": [],
+        "search_region": "",
+        "search_backend_fallback": True,
+    }
+
+    def _config(self, **overrides: Any) -> dict[str, Any]:
+        merged = dict(self._CONFIG_BASE)
+        merged.update(overrides)
+        return merged
+
+    def test_default_backend_calls_searxng(self) -> None:
+        searxng_calls: list[tuple[str, int]] = []
+        ddg_calls: list[tuple[str, int]] = []
+
+        def fake_searxng(query: str, limit: int, **_: Any) -> list[SearchResult]:
+            searxng_calls.append((query, limit))
+            return [SearchResult(1, "ok", "https://example.com/", "")]
+
+        def fake_ddg(query: str, limit: int) -> list[SearchResult]:
+            ddg_calls.append((query, limit))
+            return []
+
+        with patch.object(web_search_service, "_searxng_search", new=fake_searxng), patch.object(
+            web_search_service, "_duckduckgo_search", new=fake_ddg
+        ):
+            results = _dispatch_search("q", 5, config=self._config())
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(searxng_calls), 1)
+        self.assertEqual(ddg_calls, [])
+
+    def test_searxng_failure_falls_back_to_ddg_when_enabled(self) -> None:
+        def failing_searxng(*args: Any, **kwargs: Any) -> list[SearchResult]:
+            raise SearchBackendUnavailable("searxng down")
+
+        def fake_ddg(query: str, limit: int) -> list[SearchResult]:
+            return [SearchResult(1, "DDG", "https://duck.example/", "snippet")]
+
+        with patch.object(
+            web_search_service, "_searxng_search", new=failing_searxng
+        ), patch.object(web_search_service, "_duckduckgo_search", new=fake_ddg):
+            results = _dispatch_search(
+                "q", 5, config=self._config(search_backend_fallback=True)
+            )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].title, "DDG")
+
+    def test_searxng_failure_raises_when_fallback_disabled(self) -> None:
+        def failing_searxng(*args: Any, **kwargs: Any) -> list[SearchResult]:
+            raise SearchBackendUnavailable("searxng down")
+
+        def fake_ddg(query: str, limit: int) -> list[SearchResult]:
+            self.fail("DDG should not be called when fallback is disabled")
+            return []
+
+        with patch.object(
+            web_search_service, "_searxng_search", new=failing_searxng
+        ), patch.object(web_search_service, "_duckduckgo_search", new=fake_ddg):
+            with self.assertRaises(SearchBackendError):
+                _dispatch_search(
+                    "q", 5, config=self._config(search_backend_fallback=False)
+                )
+
+    def test_duckduckgo_backend_skips_searxng_entirely(self) -> None:
+        def fake_searxng(*args: Any, **kwargs: Any) -> list[SearchResult]:
+            self.fail("SearXNG should not be called for the duckduckgo backend")
+            return []
+
+        def fake_ddg(query: str, limit: int) -> list[SearchResult]:
+            return [SearchResult(1, "DDG", "https://duck.example/", "snippet")]
+
+        with patch.object(
+            web_search_service, "_searxng_search", new=fake_searxng
+        ), patch.object(web_search_service, "_duckduckgo_search", new=fake_ddg):
+            results = _dispatch_search(
+                "q", 5, config=self._config(search_backend="duckduckgo")
+            )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].title, "DDG")
+
+    def test_auto_backend_falls_back_regardless_of_fallback_flag(self) -> None:
+        def failing_searxng(*args: Any, **kwargs: Any) -> list[SearchResult]:
+            raise SearchBackendUnavailable("nope")
+
+        def fake_ddg(query: str, limit: int) -> list[SearchResult]:
+            return [SearchResult(1, "DDG", "https://duck.example/", "")]
+
+        with patch.object(
+            web_search_service, "_searxng_search", new=failing_searxng
+        ), patch.object(web_search_service, "_duckduckgo_search", new=fake_ddg):
+            results = _dispatch_search(
+                "q",
+                5,
+                config=self._config(
+                    search_backend="auto", search_backend_fallback=False
+                ),
+            )
+
+        self.assertEqual(len(results), 1)
+
+    def test_invalid_backend_falls_back_to_default(self) -> None:
+        def fake_searxng(*args: Any, **kwargs: Any) -> list[SearchResult]:
+            return [SearchResult(1, "ok", "https://example.com/", "")]
+
+        with patch.object(web_search_service, "_searxng_search", new=fake_searxng):
+            results = _dispatch_search(
+                "q", 5, config=self._config(search_backend="bogus")
+            )
+
+        self.assertEqual(len(results), 1)
+
+    def test_search_default_uses_searxng(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_searxng(query: str, limit: int, *, url: str, **kwargs: Any) -> list[SearchResult]:
+            captured["url"] = url
+            captured["query"] = query
+            return [SearchResult(1, "ok", "https://example.com/", "")]
+
+        with patch.object(
+            web_search_service, "_load_search_config", return_value=self._config()
+        ), patch.object(web_search_service, "_searxng_search", new=fake_searxng):
+            results = search("hello")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(captured["url"], "http://searxng:8080/search")
+        self.assertEqual(captured["query"], "hello")
+
+    def test_default_searxng_url_constant_matches_issue(self) -> None:
+        self.assertEqual(DEFAULT_SEARXNG_URL, "http://searxng:8080/search")
+
+
+class ConfigCoercionTests(unittest.TestCase):
+    def test_default_search_backend_is_searxng(self) -> None:
+        from services.research_config_service import DEFAULT_RESEARCH_CONFIG
+
+        self.assertEqual(DEFAULT_RESEARCH_CONFIG["search_backend"], "searxng")
+        self.assertEqual(
+            DEFAULT_RESEARCH_CONFIG["search_backend_url"],
+            "http://searxng:8080/search",
+        )
+        self.assertTrue(DEFAULT_RESEARCH_CONFIG["search_backend_fallback"])
+
+    def test_invalid_backend_raises(self) -> None:
+        from services.research_config_service import _coerce_config
+
+        with self.assertRaises(ValueError):
+            _coerce_config({"search_backend": "yandex"})
+
+    def test_country_aliases_to_region(self) -> None:
+        from services.research_config_service import _coerce_config
+
+        config = _coerce_config({"search_country": "us-en"})
+        self.assertEqual(config["search_region"], "us-en")
+        self.assertNotIn("search_country", config)
+
+    def test_engines_comma_string_is_normalized_to_list(self) -> None:
+        from services.research_config_service import _coerce_config
+
+        config = _coerce_config({"search_engines": "google, bing , duckduckgo"})
+        self.assertEqual(config["search_engines"], ["google", "bing", "duckduckgo"])
+
+    def test_searxng_url_env_overrides_config(self) -> None:
+        from services.research_config_service import _coerce_config
+
+        with patch.dict("os.environ", {"SEARXNG_URL": "http://example.test/search"}):
+            config = _coerce_config({"search_backend_url": "http://other:8080/"})
+        self.assertEqual(config["search_backend_url"], "http://example.test/search")
+
+    def test_duckduckgo_backend_preserves_existing_behavior(self) -> None:
+        from services.research_config_service import _coerce_config
+
+        config = _coerce_config({"search_backend": "duckduckgo"})
+        self.assertEqual(config["search_backend"], "duckduckgo")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes a SearXNG-compatible search backend the default while keeping the existing DuckDuckGo HTML scraper as a configurable fallback. Backend selection lives inside services/web_search_service.py so the FastAPI server, MCP server, and the agentic_research pipeline keep working unchanged. SearchResult is unchanged, no new runtime dependencies were added, and the existing DuckDuckGo code is preserved as _duckduckgo_search.

New config fields in configs/research_config.json:
- search_backend: "searxng" (default), "duckduckgo", or "auto"
- search_backend_url: SearXNG endpoint, overridable via SEARXNG_URL env var
- search_engines: optional engine list passed through to SearXNG
- search_region: optional locale (search_country accepted as alias)
- search_backend_fallback: enable DDG fallback on SearXNG failure (default true)

The SearchBackendError / SearchBackendUnavailable / SearchBackendBlocked hierarchy lets the dispatcher distinguish a real backend failure (network, non-200, non-JSON body, DDG 403 or CAPTCHA) from a legitimate empty result set, so fallback only fires on the former. Both backends share the existing blocked_domains filter.

Docker: adds a searxng service in compose.yaml using the official searxng/searxng image and a minimal searxng/settings.yml that enables JSON output (disabled by default in stock SearXNG). The mcp and fastapi services get SEARXNG_URL set automatically. The single-container docker run and from-source paths rely on the fallback, since they have no local SearXNG.

Tests cover SearXNG JSON parsing, JSON-disabled detection, DDG 403 and challenge handling, dispatcher fallback behavior, config defaults, and blocked_domains filtering on both backends. The pipeline reports a distinct search_backend_error status when all backends fail. README updated with the Search backends section.