### PR TITLE
Add /scrape endpoint and scrape_url MCP tool for direct URL inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,16 @@ Stop and remove the containers later with:
 docker compose -f "https://github.com/MarcellM01/TinySearch.git#main:compose.quickstart.yaml" down
 ```
 
-TinySearch exposes one MCP tool:
+TinySearch exposes two MCP tools:
 
 ```text
 research(query)
+scrape_url(url, query, max_tokens=4000)
 ```
 
-Pass the user's question as-is. TinySearch searches, crawls, reranks, and
+Pass the user's question as-is. `research` searches, crawls, reranks, and
+returns the grounded prompt in `answer`. `scrape_url` inspects a specific URL
+the caller already knows, applies the same ranking and token budget, and
 returns the grounded prompt in `answer`.
 
 ## Community
@@ -279,7 +282,37 @@ Endpoints:
 - `GET /health`
 - `GET /web_search?query=...`
 - `POST /site_crawl`
+- `POST /scrape`
 - `POST /research`
+
+`POST /scrape` accepts a JSON body with `url` (required), `query` (required,
+non-empty), `max_tokens` (optional, default 4000) and `include_metadata`
+(optional, default true). The response includes a `URL-GROUNDED ANSWER PROMPT`
+in `answer`, plus `content_tokens`, `answer_tokens`, `truncated`, `url`,
+`title`, `retrieved_at` (aware UTC) and best-effort `metadata`
+(`description`, `author`, `published_date`).
+
+Errors return `{"detail": {"code", "message"}}` with stable codes:
+`invalid_url` (400), `blocked_url` (403), `unsupported_document` (415),
+`empty_content` (422), `fetch_failed` (502), `fetch_timeout` (504).
+
+### URL safety
+
+`/scrape` and `scrape_url` accept arbitrary user-supplied URLs and enforce
+the following checks before fetching:
+
+- only `http` and `https` schemes
+- URLs with embedded credentials are rejected
+- IP literals and resolved addresses that are loopback, private, link-local,
+  multicast, reserved or unspecified are rejected (DNS rebinding is mitigated
+  by rejecting if **any** resolved address is non-public, not just one)
+- the configured `blocked_domains` list is applied to both the initial URL
+  and the final URL reported by the crawler after redirects
+
+Crawl4AI does not expose intermediate redirect hops, so the safety check runs
+on the initial URL and the final URL. If you need stricter handling for
+redirect chains, run TinySearch behind an egress proxy that enforces your
+policy.
 
 ## Configuration
 

--- a/pipelines/agentic_research.py
+++ b/pipelines/agentic_research.py
@@ -36,6 +36,7 @@ from services.embedding_service import (
     resolve_embedding_tokenizer_name,
 )
 from services.chunk_pool_selection_service import select_chunks_with_quota_and_fill
+from services.grounded_prompt_service import format_search_grounded_prompt
 from services.hybrid_embed_search_service import EmbeddingFn, rank_chunks_hybrid
 from services.research_config_service import (
     config_trace_path,
@@ -59,8 +60,6 @@ CrawlFn = Callable[..., Awaitable[dict[str, Any]]]
 _HTTP_URL = re.compile(r"^https?://", re.IGNORECASE)
 DEFAULT_DENSE_QUERY_PREFIX = "task: search result | query: "
 DEFAULT_DENSE_DOCUMENT_PREFIX = "title: none | text: "
-PROMPT_RULE = "=" * 88
-FIELD_RULE = "======"
 
 
 @dataclass(frozen=True)
@@ -128,119 +127,6 @@ def _search_chunk(result: SearchResult) -> dict[str, Any]:
         "snippet": result.text,
         "text": _search_result_doc(result),
     }
-
-
-def _format_relevant_text(chunks: Sequence[dict[str, Any]]) -> str:
-    blocks: list[str] = []
-    for ordinal, chunk in enumerate(chunks, start=1):
-        text = str(chunk.get("text") or "").strip()
-        if not text:
-            continue
-        blocks.extend(
-            [
-                f"----- RELEVANT CHUNK {ordinal} -----",
-                text,
-            ]
-        )
-    return "\n".join(blocks).strip()
-
-
-def _format_results_prompt(
-    *,
-    question: str,
-    results: Sequence[dict[str, Any]],
-    today: str | None = None,
-) -> str:
-    clean_question = question.strip()
-    today_text = today or datetime.now(UTC).date().isoformat()
-    lines = [
-        PROMPT_RULE,
-        "SEARCH-GROUNDED ANSWER PROMPT",
-        PROMPT_RULE,
-        "",
-        "QUESTION",
-        PROMPT_RULE,
-        clean_question,
-        PROMPT_RULE,
-        "",
-        "TODAY",
-        PROMPT_RULE,
-        today_text,
-        PROMPT_RULE,
-        "",
-        "CRITICAL INSTRUCTIONS",
-        PROMPT_RULE,
-        "You are answering the QUESTION using only the text under RESULTS.",
-        "First resolve any relative date in the QUESTION using TODAY.",
-        f"TODAY is {today_text!r}.",
-        f"For example, 'last year' means calendar year {int(today_text.split('-')[0]) - 1}.",
-        "Use only facts directly supported by RESULTS.",
-        "Do not use your own knowledge.",
-        "Do not add extra historical claims unless directly supported by RESULTS.",
-        "Do not infer 'first ever', 'most recent', 'record', or franchise history unless RESULTS explicitly support it.",
-        "If RESULTS contain conflicting information, prefer the result that directly matches the resolved date and question.",
-        "If the conflict cannot be resolved, say the results conflict.",
-        "Cite the source URL after each factual claim.",
-        "If the answer is not directly supported by RESULTS, say the results are not enough.",
-        PROMPT_RULE,
-        "",
-        PROMPT_RULE,
-        "RESULTS",
-        PROMPT_RULE,
-        "",
-    ]
-
-    for ordinal, result in enumerate(results, start=1):
-        relevant_text = _format_relevant_text(result.get("ranked_chunks") or [])
-        lines.extend(
-            [
-                PROMPT_RULE,
-                f"RESULT {ordinal}",
-                PROMPT_RULE,
-                f"TITLE {ordinal}",
-                FIELD_RULE,
-                str(result["title"]).strip(),
-                FIELD_RULE,
-                f"URL {ordinal}",
-                FIELD_RULE,
-                str(result["url"]).strip(),
-                FIELD_RULE,
-                f"SEARCH PREVIEW {ordinal}",
-                FIELD_RULE,
-                str(result.get("snippet") or "").strip(),
-                FIELD_RULE,
-            ]
-        )
-        if relevant_text:
-            lines.extend(
-                [
-                    f"RELEVANT TEXT {ordinal}",
-                    FIELD_RULE,
-                    relevant_text,
-                    FIELD_RULE,
-                ]
-            )
-        lines.append("")
-
-    lines.extend(
-        [
-            PROMPT_RULE,
-            "QUESTION",
-            PROMPT_RULE,
-            clean_question,
-            PROMPT_RULE,
-            "",
-            "TODAY",
-            PROMPT_RULE,
-            today_text,
-            PROMPT_RULE,
-            "",
-            PROMPT_RULE,
-            "SEARCH-GROUNDED ANSWER PROMPT",
-            PROMPT_RULE,
-        ]
-    )
-    return "\n".join(lines).strip()
 
 
 async def _rank(
@@ -427,7 +313,7 @@ async def agentic_run(
             except SearchBackendError as exc:
                 _agentic_log(f"search backend error: {exc}")
                 await emit("search_backend_error", error=str(exc))
-                prompt = _format_results_prompt(question=query, results=[])
+                prompt = format_search_grounded_prompt(question=query, results=[])
                 return finish("search_backend_error", prompt, [])
             results = [result for result in raw_results if _is_http_url(result.url)]
             results = filter_blocked_search_results(results, blocked_domains or [])
@@ -436,7 +322,7 @@ async def agentic_run(
             await emit("search_results", results_count=len(results))
 
             if not results:
-                prompt = _format_results_prompt(question=query, results=[])
+                prompt = format_search_grounded_prompt(question=query, results=[])
                 return finish("no_search_results", prompt, [])
 
             tokenizer_name = (
@@ -593,13 +479,13 @@ async def agentic_run(
                 chunks_in_prompt=len(ranked_chunk_pool),
                 crawl_errors_count=len(crawl_errors),
             )
-            prompt = _format_results_prompt(question=query, results=crawled_results)
+            prompt = format_search_grounded_prompt(question=query, results=crawled_results)
             await emit("done", results_count=len(crawled_results), crawl_errors_count=len(crawl_errors))
             _agentic_log(f"done results={len(crawled_results)} crawl_errors={len(crawl_errors)}")
             return finish("ok", prompt, crawl_errors)
     except TimeoutError:
         _agentic_log(f"timeout query={query!r} limit_s={pipeline_timeout_seconds}")
-        prompt = _format_results_prompt(question=query, results=[])
+        prompt = format_search_grounded_prompt(question=query, results=[])
         return finish("timeout", prompt, [])
 
 

--- a/servers/fastapi_server.py
+++ b/servers/fastapi_server.py
@@ -11,7 +11,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, HttpUrl
 
 from pipelines.agentic_research import agentic_run
@@ -23,7 +23,14 @@ from services.research_config_service import (
     research_run_kwargs,
     research_tokenizer_name,
 )
+from services.scrape_service import (
+    DEFAULT_SCRAPE_MAX_TOKENS,
+    SCRAPE_ERROR_MAP,
+    ScrapeError,
+    scrape_url,
+)
 from services.site_crawl_service import crawl_search
+from services.url_safety_service import BlockedUrlError, InvalidUrlError
 from services.web_search_service import (
     filter_blocked_search_results,
     search,
@@ -74,6 +81,13 @@ class SiteCrawlRequest(BaseModel):
     crawl4ai_bm25_threshold: float = Field(default=1.5, ge=0)
     crawl4ai_language: str = "english"
     encoding_name: str | None = None
+
+
+class ScrapeRequest(BaseModel):
+    url: HttpUrl
+    query: str = Field(..., min_length=1)
+    max_tokens: int = Field(default=DEFAULT_SCRAPE_MAX_TOKENS, ge=1, le=200_000)
+    include_metadata: bool = True
 
 
 class ResearchRequest(BaseModel):
@@ -174,6 +188,56 @@ async def site_crawl_get(
             url=url,
             query=query,
             top_k=top_k,
+        )
+    )
+
+
+def _raise_scrape_http_error(exc: Exception) -> None:
+    mapping = SCRAPE_ERROR_MAP.get(type(exc))
+    if mapping is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"code": "internal_error", "message": "internal error"},
+        ) from exc
+    code, status_code = mapping
+    raise HTTPException(
+        status_code=status_code,
+        detail={"code": code, "message": str(exc)},
+    ) from exc
+
+
+@app.post("/scrape")
+async def scrape_endpoint(request: ScrapeRequest) -> dict[str, Any]:
+    config = load_research_config()
+    await _ensure_local_bundle_for_config(config)
+    tokenizer = research_tokenizer_name(config)
+    try:
+        result = await scrape_url(
+            str(request.url),
+            request.query,
+            max_tokens=request.max_tokens,
+            include_metadata=request.include_metadata,
+            config=config,
+            tokenizer_name=tokenizer,
+        )
+    except (InvalidUrlError, BlockedUrlError, ScrapeError) as exc:
+        _raise_scrape_http_error(exc)
+    return result.to_response(include_metadata=request.include_metadata)
+
+
+@app.get("/scrape")
+async def scrape_get(
+    url: HttpUrl,
+    query: str,
+    max_tokens: int = DEFAULT_SCRAPE_MAX_TOKENS,
+    include_metadata: bool = True,
+) -> dict[str, Any]:
+    return await scrape_endpoint(
+        ScrapeRequest(
+            url=url,
+            query=query,
+            max_tokens=max_tokens,
+            include_metadata=include_metadata,
         )
     )
 

--- a/servers/mcp_server.py
+++ b/servers/mcp_server.py
@@ -24,7 +24,14 @@ from services.research_config_service import (
     research_run_kwargs,
     research_tokenizer_name,
 )
+from services.scrape_service import (
+    DEFAULT_SCRAPE_MAX_TOKENS,
+    SCRAPE_ERROR_MAP,
+    ScrapeError,
+    scrape_url,
+)
 from services.token_counter_service import token_count
+from services.url_safety_service import BlockedUrlError, InvalidUrlError
 
 
 def _mcp_host() -> str:
@@ -125,19 +132,25 @@ async def _run_streamable_http_combined_async() -> None:
 
 
 MCP_INSTRUCTIONS = """
-This MCP server exposes one high-level web research tool:
+This MCP server exposes two high-level web tools:
 
 1. research(query)
+2. scrape_url(url, query, max_tokens=4000)
 
 Pass the user's question as-is in query. Do not rewrite, correct spelling,
 expand abbreviations, add dates, add missing context, simplify, translate, or
-otherwise improve the user's wording before calling the tool.
+otherwise improve the user's wording before calling either tool.
 
-The tool runs a web search through the configured backend (SearXNG by default,
+research runs a web search through the configured backend (SearXNG by default,
 with a DuckDuckGo fallback), ranks search results with dense embeddings and
 BM25 using reciprocal rank fusion, crawls kept pages, ranks page chunks, and
-returns a prompt in the answer field. The caller's LLM should answer from that
-prompt and cite source URLs from the result blocks.
+returns a grounded prompt in the answer field.
+
+scrape_url inspects a specific URL the caller already knows. Use it when the
+user provides a URL or when a previous search result already identified the
+page to inspect. It crawls the page, extracts clean markdown, ranks chunks
+against the query and returns a grounded answer prompt within a token budget.
+The caller's LLM should answer from that prompt and cite the source URL.
 """.strip()
 
 
@@ -212,6 +225,57 @@ async def research(query: str) -> dict[str, Any]:
         elapsed = time.monotonic() - started
         _log(f"research failed elapsed={elapsed:.2f}s error={exc!r}")
         raise
+
+
+@mcp.tool(
+    name="scrape_url",
+    title="Scrape URL",
+    description=(
+        "Inspect a specific URL and return a grounded answer prompt containing "
+        "the page content most relevant to the requested query. Use this when "
+        "the user provides a URL or when a previous search result already "
+        "identified the page to inspect. Pass the user's query without rewriting it."
+    ),
+)
+async def scrape_url_tool(
+    url: str,
+    query: str,
+    max_tokens: int = DEFAULT_SCRAPE_MAX_TOKENS,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    _log(f"scrape_url called url={url!r} query={query!r} max_tokens={max_tokens}")
+    cfg = load_research_config()
+    _ensure_local_bundle_for_config(cfg)
+    tokenizer = research_tokenizer_name(cfg)
+    try:
+        result = await scrape_url(
+            url,
+            query,
+            max_tokens=max_tokens,
+            include_metadata=True,
+            config=cfg,
+            tokenizer_name=tokenizer,
+        )
+    except (InvalidUrlError, BlockedUrlError, ScrapeError) as exc:
+        elapsed = time.monotonic() - started
+        code = SCRAPE_ERROR_MAP.get(type(exc), ("internal_error", 500))[0]
+        _log(f"scrape_url failed elapsed={elapsed:.2f}s code={code} error={exc!r}")
+        raise ValueError(f"{code}: {exc}") from exc
+    elapsed = time.monotonic() - started
+    _log(
+        f"scrape_url returning content_tokens={result.content_tokens} "
+        f"answer_tokens={result.answer_tokens} truncated={result.truncated} "
+        f"elapsed={elapsed:.2f}s"
+    )
+    return {
+        "answer": result.answer,
+        "url": result.url,
+        "title": result.title,
+        "content_tokens": result.content_tokens,
+        "answer_tokens": result.answer_tokens,
+        "truncated": result.truncated,
+        "retrieved_at": result.retrieved_at,
+    }
 
 
 if __name__ == "__main__":

--- a/services/grounded_prompt_service.py
+++ b/services/grounded_prompt_service.py
@@ -1,0 +1,220 @@
+"""Shared, testable prompt builders for grounded answer prompts.
+
+Both `/research` (search-grounded, multi-source) and `/scrape` (URL-grounded,
+single-source) construct answer prompts in the same family of formats. Keeping
+the builders here avoids drift between adapters and lets us cover them with
+focused tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+
+PROMPT_RULE = "=" * 88
+FIELD_RULE = "======"
+
+
+def format_relevant_text(chunks: Sequence[dict[str, Any]]) -> str:
+    blocks: list[str] = []
+    for ordinal, chunk in enumerate(chunks, start=1):
+        text = str(chunk.get("text") or "").strip()
+        if not text:
+            continue
+        blocks.extend(
+            [
+                f"----- RELEVANT CHUNK {ordinal} -----",
+                text,
+            ]
+        )
+    return "\n".join(blocks).strip()
+
+
+def _today_text(today: str | None) -> str:
+    return today or datetime.now(UTC).date().isoformat()
+
+
+def format_search_grounded_prompt(
+    *,
+    question: str,
+    results: Sequence[dict[str, Any]],
+    today: str | None = None,
+) -> str:
+    clean_question = question.strip()
+    today_text = _today_text(today)
+    lines = [
+        PROMPT_RULE,
+        "SEARCH-GROUNDED ANSWER PROMPT",
+        PROMPT_RULE,
+        "",
+        "QUESTION",
+        PROMPT_RULE,
+        clean_question,
+        PROMPT_RULE,
+        "",
+        "TODAY",
+        PROMPT_RULE,
+        today_text,
+        PROMPT_RULE,
+        "",
+        "CRITICAL INSTRUCTIONS",
+        PROMPT_RULE,
+        "You are answering the QUESTION using only the text under RESULTS.",
+        "First resolve any relative date in the QUESTION using TODAY.",
+        f"TODAY is {today_text!r}.",
+        f"For example, 'last year' means calendar year {int(today_text.split('-')[0]) - 1}.",
+        "Use only facts directly supported by RESULTS.",
+        "Do not use your own knowledge.",
+        "Do not add extra historical claims unless directly supported by RESULTS.",
+        "Do not infer 'first ever', 'most recent', 'record', or franchise history unless RESULTS explicitly support it.",
+        "If RESULTS contain conflicting information, prefer the result that directly matches the resolved date and question.",
+        "If the conflict cannot be resolved, say the results conflict.",
+        "Cite the source URL after each factual claim.",
+        "If the answer is not directly supported by RESULTS, say the results are not enough.",
+        PROMPT_RULE,
+        "",
+        PROMPT_RULE,
+        "RESULTS",
+        PROMPT_RULE,
+        "",
+    ]
+
+    for ordinal, result in enumerate(results, start=1):
+        relevant_text = format_relevant_text(result.get("ranked_chunks") or [])
+        lines.extend(
+            [
+                PROMPT_RULE,
+                f"RESULT {ordinal}",
+                PROMPT_RULE,
+                f"TITLE {ordinal}",
+                FIELD_RULE,
+                str(result["title"]).strip(),
+                FIELD_RULE,
+                f"URL {ordinal}",
+                FIELD_RULE,
+                str(result["url"]).strip(),
+                FIELD_RULE,
+                f"SEARCH PREVIEW {ordinal}",
+                FIELD_RULE,
+                str(result.get("snippet") or "").strip(),
+                FIELD_RULE,
+            ]
+        )
+        if relevant_text:
+            lines.extend(
+                [
+                    f"RELEVANT TEXT {ordinal}",
+                    FIELD_RULE,
+                    relevant_text,
+                    FIELD_RULE,
+                ]
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            PROMPT_RULE,
+            "QUESTION",
+            PROMPT_RULE,
+            clean_question,
+            PROMPT_RULE,
+            "",
+            "TODAY",
+            PROMPT_RULE,
+            today_text,
+            PROMPT_RULE,
+            "",
+            PROMPT_RULE,
+            "SEARCH-GROUNDED ANSWER PROMPT",
+            PROMPT_RULE,
+        ]
+    )
+    return "\n".join(lines).strip()
+
+
+def format_url_grounded_prompt(
+    *,
+    question: str,
+    url: str,
+    title: str,
+    ranked_chunks: Sequence[dict[str, Any]],
+    today: str | None = None,
+) -> str:
+    clean_question = question.strip()
+    today_text = _today_text(today)
+    lines = [
+        PROMPT_RULE,
+        "URL-GROUNDED ANSWER PROMPT",
+        PROMPT_RULE,
+        "",
+        "QUESTION",
+        PROMPT_RULE,
+        clean_question,
+        PROMPT_RULE,
+        "",
+        "TODAY",
+        PROMPT_RULE,
+        today_text,
+        PROMPT_RULE,
+        "",
+        "CRITICAL INSTRUCTIONS",
+        PROMPT_RULE,
+        "You are answering the QUESTION using only the text under PAGE.",
+        "First resolve any relative date in the QUESTION using TODAY.",
+        f"TODAY is {today_text!r}.",
+        f"For example, 'last year' means calendar year {int(today_text.split('-')[0]) - 1}.",
+        "Use only facts directly supported by the page evidence.",
+        "Do not use your own knowledge.",
+        "Do not add extra historical claims unless directly supported by the page.",
+        "Do not infer 'first', 'latest', or 'most recent' unless the page explicitly supports it.",
+        "Cite the page URL after each factual claim.",
+        "If the answer is not directly supported by the page, say the page is insufficient.",
+        PROMPT_RULE,
+        "",
+        PROMPT_RULE,
+        "PAGE",
+        PROMPT_RULE,
+        "",
+        "TITLE",
+        FIELD_RULE,
+        str(title).strip(),
+        FIELD_RULE,
+        "URL",
+        FIELD_RULE,
+        str(url).strip(),
+        FIELD_RULE,
+    ]
+
+    relevant_text = format_relevant_text(ranked_chunks)
+    if relevant_text:
+        lines.extend(
+            [
+                "RELEVANT TEXT",
+                FIELD_RULE,
+                relevant_text,
+                FIELD_RULE,
+            ]
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            PROMPT_RULE,
+            "QUESTION",
+            PROMPT_RULE,
+            clean_question,
+            PROMPT_RULE,
+            "",
+            "TODAY",
+            PROMPT_RULE,
+            today_text,
+            PROMPT_RULE,
+            "",
+            PROMPT_RULE,
+            "URL-GROUNDED ANSWER PROMPT",
+            PROMPT_RULE,
+        ]
+    )
+    return "\n".join(lines).strip()

--- a/services/scrape_service.py
+++ b/services/scrape_service.py
@@ -1,0 +1,360 @@
+"""Single-URL scrape orchestrator backing /scrape and the MCP scrape_url tool.
+
+Implements upstream issue #10: validate the URL, fetch it through the existing
+Crawl4AI path or the bundled PDF/DOCX extractor, chunk and rank the extracted
+markdown against the caller's query, select chunks under a token budget, and
+return a grounded answer prompt plus token accounting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import socket
+import urllib.error
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+from services.grounded_prompt_service import format_url_grounded_prompt
+from services.site_crawl_service import (
+    _extract_document_text,
+    _is_document_url,
+    _url_path_suffix,
+    fetch_html_for_query,
+    rank_chunks_bm25,
+)
+from services.text_chunking_service import chunk_text
+from services.token_counter_service import (
+    decode_tokens,
+    encode_tokens,
+    token_count,
+)
+from services.url_safety_service import (
+    BlockedUrlError,
+    InvalidUrlError,
+    assert_url_is_fetchable,
+)
+
+
+DEFAULT_SCRAPE_MAX_TOKENS = 4000
+
+
+class ScrapeError(Exception):
+    """Base error for /scrape failures other than URL safety."""
+
+
+class FetchTimeoutError(ScrapeError):
+    """Fetching the URL exceeded the pipeline timeout."""
+
+
+class FetchFailedError(ScrapeError):
+    """Fetching the URL failed for a non-timeout reason."""
+
+
+class UnsupportedDocumentError(ScrapeError):
+    """The URL points to a document format the scrape pipeline cannot read."""
+
+
+class EmptyContentError(ScrapeError):
+    """The page produced no usable text after extraction and chunking."""
+
+
+SCRAPE_ERROR_MAP: dict[type, tuple[str, int]] = {
+    InvalidUrlError: ("invalid_url", 400),
+    BlockedUrlError: ("blocked_url", 403),
+    FetchTimeoutError: ("fetch_timeout", 504),
+    FetchFailedError: ("fetch_failed", 502),
+    UnsupportedDocumentError: ("unsupported_document", 415),
+    EmptyContentError: ("empty_content", 422),
+}
+
+
+@dataclass(frozen=True)
+class ScrapeResult:
+    answer: str
+    url: str
+    title: str
+    query: str
+    content_tokens: int
+    answer_tokens: int
+    truncated: bool
+    retrieved_at: str
+    metadata: dict[str, str | None] | None = None
+
+    def to_response(self, *, include_metadata: bool) -> dict[str, Any]:
+        payload = asdict(self)
+        if not include_metadata:
+            payload.pop("metadata", None)
+        return payload
+
+
+_TITLE_RE = re.compile(r"<title[^>]*>([^<]+)</title>", re.IGNORECASE)
+_META_NAME_FIRST_RE = re.compile(
+    r'<meta\s+[^>]*?(?:name|property)\s*=\s*["\']([^"\']+)["\'][^>]*?content\s*=\s*["\']([^"\']*)["\'][^>]*>',
+    re.IGNORECASE,
+)
+_META_CONTENT_FIRST_RE = re.compile(
+    r'<meta\s+[^>]*?content\s*=\s*["\']([^"\']*)["\'][^>]*?(?:name|property)\s*=\s*["\']([^"\']+)["\'][^>]*>',
+    re.IGNORECASE,
+)
+
+
+def _scan_html_meta(html: str) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for key, value in _META_NAME_FIRST_RE.findall(html or ""):
+        found.setdefault(key.strip().lower(), value.strip())
+    for value, key in _META_CONTENT_FIRST_RE.findall(html or ""):
+        found.setdefault(key.strip().lower(), value.strip())
+    return found
+
+
+def _coerce_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()
+
+
+def _extract_title(crawl_metadata: dict[str, Any], html: str) -> str:
+    title = _coerce_str(crawl_metadata.get("title"))
+    if title:
+        return title
+    match = _TITLE_RE.search(html or "")
+    if match:
+        return match.group(1).strip()
+    return ""
+
+
+def _extract_metadata(
+    crawl_metadata: dict[str, Any], html: str
+) -> dict[str, str | None]:
+    html_meta = _scan_html_meta(html)
+
+    def _pick(*keys: str) -> str | None:
+        for key in keys:
+            val = _coerce_str(crawl_metadata.get(key))
+            if val:
+                return val
+            val = html_meta.get(key.lower(), "").strip()
+            if val:
+                return val
+        return None
+
+    return {
+        "description": _pick("description", "og:description"),
+        "author": _pick("author", "article:author"),
+        "published_date": _pick(
+            "article:published_time",
+            "og:article:published_time",
+            "date",
+            "datePublished",
+        ),
+    }
+
+
+def _utc_iso8601_z(now: datetime | None = None) -> str:
+    moment = now or datetime.now(UTC)
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _select_chunks_under_budget(
+    ranked: list[dict[str, Any]],
+    max_tokens: int,
+    tokenizer: str,
+) -> tuple[list[dict[str, Any]], int, bool]:
+    selected: list[dict[str, Any]] = []
+    total = 0
+    truncated = False
+    for chunk in ranked:
+        chunk_tokens = int(chunk.get("tokens") or 0)
+        if total + chunk_tokens > max_tokens:
+            truncated = True
+            break
+        selected.append(chunk)
+        total += chunk_tokens
+    if not selected and ranked:
+        first = ranked[0]
+        text = str(first.get("text") or "")
+        tokens = encode_tokens(text, tokenizer)
+        if len(tokens) > max_tokens:
+            truncated_text = decode_tokens(tokens[:max_tokens], tokenizer)
+            selected.append({**first, "text": truncated_text, "tokens": max_tokens})
+            total = max_tokens
+            truncated = True
+    return selected, total, truncated
+
+
+HtmlCrawlFn = Callable[..., Awaitable[dict[str, Any]]]
+DocumentExtractFn = Callable[[str], tuple[str, str]]
+
+
+async def _fetch_html_with_timeout(
+    *,
+    url: str,
+    query: str,
+    bm25_threshold: float,
+    bm25_language: str,
+    timeout_seconds: float,
+    crawl_fn: HtmlCrawlFn,
+) -> dict[str, Any]:
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            return await crawl_fn(
+                url=url,
+                user_query=query,
+                bm25_threshold=bm25_threshold,
+                bm25_language=bm25_language,
+            )
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        raise FetchTimeoutError(f"fetch timed out after {timeout_seconds}s") from exc
+    except (InvalidUrlError, BlockedUrlError):
+        raise
+    except Exception as exc:  # noqa: BLE001 - mapped to a stable user-facing code
+        raise FetchFailedError(f"fetch failed: {exc}") from exc
+
+
+async def _extract_document_with_timeout(
+    *,
+    url: str,
+    timeout_seconds: float,
+    document_fn: DocumentExtractFn,
+) -> tuple[str, str]:
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            return await asyncio.to_thread(document_fn, url)
+    except (asyncio.TimeoutError, TimeoutError) as exc:
+        raise FetchTimeoutError(f"fetch timed out after {timeout_seconds}s") from exc
+    except ValueError as exc:
+        raise UnsupportedDocumentError(str(exc)) from exc
+    except (urllib.error.URLError, socket.timeout) as exc:
+        if isinstance(exc, socket.timeout):
+            raise FetchTimeoutError(f"download timed out: {exc}") from exc
+        raise FetchFailedError(f"download failed: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001
+        raise FetchFailedError(f"document extraction failed: {exc}") from exc
+
+
+async def scrape_url(
+    url: str,
+    query: str,
+    *,
+    max_tokens: int = DEFAULT_SCRAPE_MAX_TOKENS,
+    include_metadata: bool = True,
+    config: dict[str, Any],
+    tokenizer_name: str,
+    crawl_fn: HtmlCrawlFn | None = None,
+    document_fn: DocumentExtractFn | None = None,
+) -> ScrapeResult:
+    """Inspect a single URL and return a grounded answer prompt for `query`.
+
+    `config` carries the research-config values we need (blocked_domains,
+    crawl/chunk parameters, pipeline_timeout_seconds). `tokenizer_name` is
+    resolved by the caller via `research_tokenizer_name(config)` so we do not
+    have to import the embedding stack here.
+    """
+    cleaned_query = (query or "").strip()
+    if not cleaned_query:
+        raise ValueError("query must not be empty")
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be positive")
+
+    blocked_domains = config.get("blocked_domains") or []
+    safe_url = assert_url_is_fetchable(url, blocked_domains)
+
+    timeout_seconds = float(config.get("pipeline_timeout_seconds") or 120.0)
+    max_chunk_tokens = int(config.get("crawl_max_chunk_tokens") or 500)
+    overlap_tokens = int(config.get("crawl_overlap_tokens") or 80)
+    bm25_threshold = float(config.get("crawl_bm25_threshold") or 1.5)
+    bm25_language = str(config.get("crawl_bm25_language") or "english")
+
+    is_document = _is_document_url(safe_url)
+    final_url = safe_url
+    markdown = ""
+    html = ""
+    crawl_metadata: dict[str, Any] = {}
+
+    if is_document:
+        suffix = _url_path_suffix(safe_url)
+        if suffix == "doc":
+            raise UnsupportedDocumentError(
+                "legacy .doc files are not supported; use PDF or DOCX"
+            )
+        document_fn = document_fn or _extract_document_text
+        markdown, _document_type = await _extract_document_with_timeout(
+            url=safe_url,
+            timeout_seconds=timeout_seconds,
+            document_fn=document_fn,
+        )
+    else:
+        crawl_fn = crawl_fn or fetch_html_for_query
+        page = await _fetch_html_with_timeout(
+            url=safe_url,
+            query=cleaned_query,
+            bm25_threshold=bm25_threshold,
+            bm25_language=bm25_language,
+            timeout_seconds=timeout_seconds,
+            crawl_fn=crawl_fn,
+        )
+        final_url = str(page.get("final_url") or safe_url)
+        html = str(page.get("html") or "")
+        crawl_metadata = page.get("metadata") or {}
+        if final_url != safe_url:
+            final_url = assert_url_is_fetchable(final_url, blocked_domains)
+        markdown_raw = str(page.get("markdown_raw") or "")
+        markdown_fit = str(page.get("markdown_fit") or "")
+        markdown = markdown_fit or markdown_raw
+
+    if not markdown or not markdown.strip():
+        raise EmptyContentError(f"no readable content extracted from {final_url}")
+
+    chunks = chunk_text(
+        text=markdown,
+        max_chunk_tokens=max_chunk_tokens,
+        overlap_tokens=overlap_tokens,
+        encoding_name=tokenizer_name,
+    )
+    if not chunks:
+        raise EmptyContentError(f"no chunks produced from {final_url}")
+
+    ranked = rank_chunks_bm25(query=cleaned_query, chunks=chunks, top_k=len(chunks))
+    if not ranked:
+        ranked = chunks
+
+    selected, content_tokens, truncated = _select_chunks_under_budget(
+        ranked, max_tokens, tokenizer_name
+    )
+    if not selected:
+        raise EmptyContentError(f"no chunk fit the max_tokens budget for {final_url}")
+
+    title = "" if is_document else _extract_title(crawl_metadata, html)
+    metadata: dict[str, str | None] | None
+    if not include_metadata:
+        metadata = None
+    elif is_document:
+        metadata = {"description": None, "author": None, "published_date": None}
+    else:
+        metadata = _extract_metadata(crawl_metadata, html)
+
+    answer = format_url_grounded_prompt(
+        question=cleaned_query,
+        url=final_url,
+        title=title,
+        ranked_chunks=selected,
+    )
+    answer_tokens = token_count(answer, tokenizer_name)
+
+    return ScrapeResult(
+        answer=answer,
+        url=final_url,
+        title=title,
+        query=cleaned_query,
+        content_tokens=content_tokens,
+        answer_tokens=answer_tokens,
+        truncated=truncated,
+        retrieved_at=_utc_iso8601_z(),
+        metadata=metadata,
+    )

--- a/services/site_crawl_service.py
+++ b/services/site_crawl_service.py
@@ -313,6 +313,58 @@ async def crawl(
     }
 
 
+async def fetch_html_for_query(
+    url: str,
+    user_query: str,
+    *,
+    bm25_threshold: float = 1.5,
+    bm25_language: str = "english",
+) -> dict[str, Any]:
+    """Fetch a URL through Crawl4AI applying a BM25 content filter on the body.
+
+    Returns ``final_url``, ``html``, ``markdown_raw``, ``markdown_fit`` and the
+    crawler's ``metadata`` dict. The ``final_url`` reflects the URL after any
+    redirects Crawl4AI followed.
+    """
+    _ensure_utf8_stdio()
+
+    AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, BM25ContentFilter, _, DefaultMarkdownGenerator = (
+        _crawl4ai_stack()
+    )
+
+    bm25_filter = BM25ContentFilter(
+        user_query=user_query,
+        bm25_threshold=bm25_threshold,
+        language=bm25_language,
+    )
+    config = CrawlerRunConfig(
+        verbose=False,
+        markdown_generator=DefaultMarkdownGenerator(
+            content_filter=bm25_filter,
+            options=dict(_DEFAULT_MARKDOWN_GENERATOR_OPTIONS),
+        ),
+    )
+
+    async with AsyncWebCrawler(config=BrowserConfig(verbose=False)) as crawler:
+        result = await crawler.arun(url=url, config=config)
+
+    final_url = (
+        getattr(result, "redirected_url", None)
+        or getattr(result, "url", None)
+        or url
+    )
+    metadata_obj = getattr(result, "metadata", None)
+    metadata = dict(metadata_obj) if isinstance(metadata_obj, dict) else {}
+
+    return {
+        "final_url": str(final_url),
+        "html": _get_html(result),
+        "markdown_raw": _get_markdown_raw(result),
+        "markdown_fit": _get_markdown_fit(result) or "",
+        "metadata": metadata,
+    }
+
+
 async def crawl_search(
     url: str,
     user_query: str,
@@ -365,29 +417,15 @@ async def crawl_search(
             "document_type": document_type,
         }
 
-    AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, BM25ContentFilter, _, DefaultMarkdownGenerator = (
-        _crawl4ai_stack()
-    )
-
-    bm25_filter = BM25ContentFilter(
+    page = await fetch_html_for_query(
+        url=url,
         user_query=user_query,
         bm25_threshold=crawl4ai_bm25_threshold,
-        language=crawl4ai_language,
+        bm25_language=crawl4ai_language,
     )
-    config = CrawlerRunConfig(
-        verbose=False,
-        markdown_generator=DefaultMarkdownGenerator(
-            content_filter=bm25_filter,
-            options=dict(_DEFAULT_MARKDOWN_GENERATOR_OPTIONS),
-        )
-    )
-
-    async with AsyncWebCrawler(config=BrowserConfig(verbose=False)) as crawler:
-        result = await crawler.arun(url=url, config=config)
-
-    html = _get_html(result)
-    markdown_raw = _get_markdown_raw(result)
-    markdown_fit = _get_markdown_fit(result) or ""
+    html = page["html"]
+    markdown_raw = page["markdown_raw"]
+    markdown_fit = page["markdown_fit"]
     markdown_for_chunking = markdown_fit or markdown_raw
 
     chunks = chunk_text(

--- a/services/url_safety_service.py
+++ b/services/url_safety_service.py
@@ -1,0 +1,125 @@
+"""URL safety checks shared by /scrape and the MCP scrape_url tool.
+
+Enforces the SSRF hardening required by upstream issue #10:
+
+- Only ``http`` and ``https`` schemes.
+- Reject URLs with embedded credentials.
+- Reject IP literals and resolved addresses that are loopback, private,
+  link-local, multicast, reserved or unspecified.
+- DNS rebinding mitigation: reject the URL if ANY resolved address is
+  non-public, not just at least one.
+- Apply configured ``blocked_domains`` to both the initial URL and any
+  redirect target the caller re-validates.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterable
+from ipaddress import AddressValueError, ip_address
+from urllib.parse import urlsplit
+
+from services.web_search_service import is_blocked_domain
+
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+class InvalidUrlError(ValueError):
+    """URL is malformed, missing host, or uses a disallowed scheme."""
+
+
+class BlockedUrlError(ValueError):
+    """URL resolves to a non-public address or matches a blocked domain."""
+
+
+def _assert_public_ip(addr, *, source: str) -> None:
+    if (
+        addr.is_loopback
+        or addr.is_private
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    ):
+        raise BlockedUrlError(f"address is not publicly routable: {source}")
+
+
+def validate_public_url(url: str) -> str:
+    """Validate scheme, structure and IP literal. Does not resolve DNS.
+
+    Returns the cleaned URL string. Raises ``InvalidUrlError`` for malformed
+    URLs or disallowed schemes, and ``BlockedUrlError`` when the host is a
+    non-public IP literal.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise InvalidUrlError("URL must be a non-empty string")
+    cleaned = url.strip()
+    parsed = urlsplit(cleaned)
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise InvalidUrlError(
+            f"only http and https URLs are allowed, got {scheme or 'no scheme'!r}"
+        )
+    if parsed.username or parsed.password:
+        raise InvalidUrlError("URLs with embedded credentials are not allowed")
+    host = parsed.hostname
+    if not host:
+        raise InvalidUrlError("URL has no host")
+    try:
+        addr = ip_address(host)
+    except (ValueError, AddressValueError):
+        return cleaned
+    _assert_public_ip(addr, source=f"host literal {host!r}")
+    return cleaned
+
+
+def resolve_and_check_public(host: str) -> list[str]:
+    """Resolve ``host`` and reject if ANY resolved address is non-public.
+
+    Returns the list of resolved address strings on success.
+    """
+    if not host:
+        raise InvalidUrlError("hostname is empty")
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise InvalidUrlError(f"could not resolve host {host!r}: {exc}") from exc
+    resolved: list[str] = []
+    for info in infos:
+        sockaddr = info[4]
+        addr_text = sockaddr[0]
+        try:
+            addr = ip_address(addr_text)
+        except (ValueError, AddressValueError) as exc:
+            raise BlockedUrlError(
+                f"resolver returned non-IP address for {host!r}: {addr_text!r}"
+            ) from exc
+        _assert_public_ip(addr, source=f"{host!r} -> {addr_text}")
+        resolved.append(addr_text)
+    if not resolved:
+        raise InvalidUrlError(f"no addresses resolved for {host!r}")
+    return resolved
+
+
+def enforce_blocked_domains(url: str, blocked_domains: Iterable[str]) -> None:
+    if is_blocked_domain(url, blocked_domains):
+        raise BlockedUrlError(
+            f"URL host is in the configured blocked-domains list: {url}"
+        )
+
+
+def assert_url_is_fetchable(url: str, blocked_domains: Iterable[str]) -> str:
+    """Run scheme, credential, IP-literal, blocked-domain and DNS checks.
+
+    Returns the validated URL string. Hosts that are already IP literals skip
+    the DNS resolution step (the literal itself was already checked).
+    """
+    validated = validate_public_url(url)
+    enforce_blocked_domains(validated, blocked_domains)
+    host = urlsplit(validated).hostname or ""
+    try:
+        ip_address(host)
+    except (ValueError, AddressValueError):
+        resolve_and_check_public(host)
+    return validated

--- a/tests/test_fastapi_scrape_endpoint.py
+++ b/tests/test_fastapi_scrape_endpoint.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from servers.fastapi_server import ScrapeRequest, scrape_endpoint
+from services.scrape_service import (
+    EmptyContentError,
+    FetchFailedError,
+    FetchTimeoutError,
+    ScrapeResult,
+    UnsupportedDocumentError,
+)
+from services.url_safety_service import BlockedUrlError, InvalidUrlError
+
+
+def _result(metadata=None) -> ScrapeResult:
+    return ScrapeResult(
+        answer="URL-GROUNDED ANSWER PROMPT...",
+        url="https://example.com/x",
+        title="Title",
+        query="q",
+        content_tokens=42,
+        answer_tokens=123,
+        truncated=False,
+        retrieved_at="2026-06-12T10:30:00Z",
+        metadata=metadata,
+    )
+
+
+class ScrapeRequestValidationTests(unittest.TestCase):
+    def test_rejects_empty_query(self) -> None:
+        with self.assertRaises(ValidationError):
+            ScrapeRequest(url="https://example.com/x", query="")
+
+    def test_rejects_zero_max_tokens(self) -> None:
+        with self.assertRaises(ValidationError):
+            ScrapeRequest(url="https://example.com/x", query="q", max_tokens=0)
+
+    def test_rejects_non_http_scheme(self) -> None:
+        with self.assertRaises(ValidationError):
+            ScrapeRequest(url="ftp://example.com/x", query="q")
+
+    def test_defaults(self) -> None:
+        req = ScrapeRequest(url="https://example.com/x", query="q")
+        self.assertEqual(req.max_tokens, 4000)
+        self.assertTrue(req.include_metadata)
+
+
+class ScrapeEndpointTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_payload_with_metadata(self) -> None:
+        scrape_mock = AsyncMock(
+            return_value=_result(
+                metadata={
+                    "description": "d",
+                    "author": "a",
+                    "published_date": "2026-01-01",
+                }
+            )
+        )
+        with patch("servers.fastapi_server.scrape_url", scrape_mock), patch(
+            "servers.fastapi_server._ensure_local_bundle_for_config",
+            new_callable=AsyncMock,
+        ):
+            payload = await scrape_endpoint(
+                ScrapeRequest(url="https://example.com/x", query="q")
+            )
+
+        self.assertEqual(payload["answer"], "URL-GROUNDED ANSWER PROMPT...")
+        self.assertEqual(payload["url"], "https://example.com/x")
+        self.assertEqual(payload["title"], "Title")
+        self.assertEqual(payload["query"], "q")
+        self.assertEqual(payload["content_tokens"], 42)
+        self.assertEqual(payload["answer_tokens"], 123)
+        self.assertFalse(payload["truncated"])
+        self.assertEqual(payload["retrieved_at"], "2026-06-12T10:30:00Z")
+        self.assertEqual(payload["metadata"]["author"], "a")
+
+    async def test_omits_metadata_when_include_metadata_false(self) -> None:
+        scrape_mock = AsyncMock(return_value=_result(metadata=None))
+        with patch("servers.fastapi_server.scrape_url", scrape_mock), patch(
+            "servers.fastapi_server._ensure_local_bundle_for_config",
+            new_callable=AsyncMock,
+        ):
+            payload = await scrape_endpoint(
+                ScrapeRequest(
+                    url="https://example.com/x",
+                    query="q",
+                    include_metadata=False,
+                )
+            )
+
+        self.assertNotIn("metadata", payload)
+
+
+class ScrapeEndpointErrorMappingTests(unittest.IsolatedAsyncioTestCase):
+    async def _run_with_exc(self, exc: Exception) -> HTTPException:
+        scrape_mock = AsyncMock(side_effect=exc)
+        with patch("servers.fastapi_server.scrape_url", scrape_mock), patch(
+            "servers.fastapi_server._ensure_local_bundle_for_config",
+            new_callable=AsyncMock,
+        ):
+            try:
+                await scrape_endpoint(
+                    ScrapeRequest(url="https://example.com/x", query="q")
+                )
+            except HTTPException as raised:
+                return raised
+        self.fail("expected HTTPException")
+
+    async def test_invalid_url_maps_to_400(self) -> None:
+        raised = await self._run_with_exc(InvalidUrlError("bad"))
+        self.assertEqual(raised.status_code, 400)
+        self.assertEqual(raised.detail["code"], "invalid_url")
+
+    async def test_blocked_url_maps_to_403(self) -> None:
+        raised = await self._run_with_exc(BlockedUrlError("nope"))
+        self.assertEqual(raised.status_code, 403)
+        self.assertEqual(raised.detail["code"], "blocked_url")
+
+    async def test_fetch_timeout_maps_to_504(self) -> None:
+        raised = await self._run_with_exc(FetchTimeoutError("slow"))
+        self.assertEqual(raised.status_code, 504)
+        self.assertEqual(raised.detail["code"], "fetch_timeout")
+
+    async def test_fetch_failed_maps_to_502(self) -> None:
+        raised = await self._run_with_exc(FetchFailedError("dead"))
+        self.assertEqual(raised.status_code, 502)
+        self.assertEqual(raised.detail["code"], "fetch_failed")
+
+    async def test_unsupported_document_maps_to_415(self) -> None:
+        raised = await self._run_with_exc(UnsupportedDocumentError(".doc"))
+        self.assertEqual(raised.status_code, 415)
+        self.assertEqual(raised.detail["code"], "unsupported_document")
+
+    async def test_empty_content_maps_to_422(self) -> None:
+        raised = await self._run_with_exc(EmptyContentError("nothing"))
+        self.assertEqual(raised.status_code, 422)
+        self.assertEqual(raised.detail["code"], "empty_content")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grounded_prompt_service.py
+++ b/tests/test_grounded_prompt_service.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import unittest
+
+from services.grounded_prompt_service import (
+    FIELD_RULE,
+    PROMPT_RULE,
+    format_relevant_text,
+    format_search_grounded_prompt,
+    format_url_grounded_prompt,
+)
+
+
+def _result_block() -> dict:
+    return {
+        "title": "Example Article",
+        "url": "https://example.com/a",
+        "snippet": "Short preview text.",
+        "ranked_chunks": [
+            {"text": "First relevant chunk about installation."},
+            {"text": "Second chunk with another fact."},
+        ],
+    }
+
+
+class FormatRelevantTextTests(unittest.TestCase):
+    def test_emits_one_block_per_non_empty_chunk_keeping_original_ordinals(self) -> None:
+        out = format_relevant_text(
+            [{"text": "alpha"}, {"text": ""}, {"text": "beta"}]
+        )
+
+        self.assertIn("----- RELEVANT CHUNK 1 -----\nalpha", out)
+        self.assertIn("----- RELEVANT CHUNK 3 -----\nbeta", out)
+        self.assertNotIn("CHUNK 2", out)
+
+    def test_returns_empty_string_when_no_chunks(self) -> None:
+        self.assertEqual(format_relevant_text([]), "")
+
+
+class FormatSearchGroundedPromptTests(unittest.TestCase):
+    def test_preserves_existing_markers_and_format(self) -> None:
+        prompt = format_search_grounded_prompt(
+            question="What does it say about installation?",
+            results=[_result_block()],
+            today="2026-06-12",
+        )
+
+        self.assertIn("SEARCH-GROUNDED ANSWER PROMPT", prompt)
+        self.assertIn("CRITICAL INSTRUCTIONS", prompt)
+        self.assertIn(
+            "You are answering the QUESTION using only the text under RESULTS.",
+            prompt,
+        )
+        self.assertIn("RESULT 1", prompt)
+        self.assertIn("TITLE 1\n======\nExample Article", prompt)
+        self.assertIn("URL 1\n======\nhttps://example.com/a", prompt)
+        self.assertIn(
+            "SEARCH PREVIEW 1\n======\nShort preview text.",
+            prompt,
+        )
+        self.assertIn("RELEVANT TEXT 1\n======", prompt)
+        self.assertIn("----- RELEVANT CHUNK 1 -----", prompt)
+        self.assertIn("First relevant chunk about installation.", prompt)
+        self.assertIn("What does it say about installation?", prompt)
+        self.assertEqual(prompt.count("\nQUESTION\n"), 2)
+        self.assertEqual(prompt.count("\nTODAY\n"), 2)
+
+    def test_empty_results_still_produces_question_section(self) -> None:
+        prompt = format_search_grounded_prompt(
+            question="zero hits",
+            results=[],
+            today="2026-06-12",
+        )
+
+        self.assertIn("RESULTS", prompt)
+        self.assertNotIn("RESULT 1", prompt)
+        self.assertIn("zero hits", prompt)
+
+
+class FormatUrlGroundedPromptTests(unittest.TestCase):
+    def test_contains_required_sections_and_url_specific_rules(self) -> None:
+        prompt = format_url_grounded_prompt(
+            question="What does this page say about installation?",
+            url="https://example.com/article",
+            title="Example Article",
+            ranked_chunks=[{"text": "Run pip install."}, {"text": "Then run the CLI."}],
+            today="2026-06-12",
+        )
+
+        self.assertIn("URL-GROUNDED ANSWER PROMPT", prompt)
+        self.assertIn("CRITICAL INSTRUCTIONS", prompt)
+        self.assertIn("PAGE", prompt)
+        self.assertIn("TITLE\n======\nExample Article", prompt)
+        self.assertIn("URL\n======\nhttps://example.com/article", prompt)
+        self.assertIn("RELEVANT TEXT\n======", prompt)
+        self.assertIn("----- RELEVANT CHUNK 1 -----\nRun pip install.", prompt)
+        self.assertIn("----- RELEVANT CHUNK 2 -----\nThen run the CLI.", prompt)
+        self.assertIn(
+            "You are answering the QUESTION using only the text under PAGE.",
+            prompt,
+        )
+        self.assertIn("Cite the page URL after each factual claim.", prompt)
+        self.assertIn(
+            "If the answer is not directly supported by the page, say the page is insufficient.",
+            prompt,
+        )
+        self.assertIn(
+            "Do not infer 'first', 'latest', or 'most recent' unless the page explicitly supports it.",
+            prompt,
+        )
+        self.assertEqual(prompt.count("\nQUESTION\n"), 2)
+        self.assertEqual(prompt.count("\nTODAY\n"), 2)
+
+    def test_preserves_original_query_wording(self) -> None:
+        original = "  Does this page MENTION 'Async/Await' patterns?  "
+        prompt = format_url_grounded_prompt(
+            question=original,
+            url="https://example.com/x",
+            title="Title",
+            ranked_chunks=[{"text": "chunk"}],
+            today="2026-06-12",
+        )
+
+        self.assertIn("Does this page MENTION 'Async/Await' patterns?", prompt)
+
+    def test_today_default_uses_utc_iso_date(self) -> None:
+        from datetime import UTC, datetime
+
+        prompt = format_url_grounded_prompt(
+            question="q",
+            url="https://example.com/x",
+            title="Title",
+            ranked_chunks=[{"text": "chunk"}],
+        )
+
+        today = datetime.now(UTC).date().isoformat()
+        self.assertIn(today, prompt)
+
+    def test_no_relevant_text_section_when_chunks_empty(self) -> None:
+        prompt = format_url_grounded_prompt(
+            question="q",
+            url="https://example.com/x",
+            title="Title",
+            ranked_chunks=[],
+            today="2026-06-12",
+        )
+
+        self.assertNotIn("RELEVANT TEXT", prompt)
+        self.assertIn("PAGE", prompt)
+
+
+class ConstantsTests(unittest.TestCase):
+    def test_prompt_rule_and_field_rule_are_exposed(self) -> None:
+        self.assertEqual(PROMPT_RULE, "=" * 88)
+        self.assertEqual(FIELD_RULE, "======")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_scrape_tool.py
+++ b/tests/test_mcp_scrape_tool.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from servers.mcp_server import scrape_url_tool
+from services.scrape_service import (
+    EmptyContentError,
+    FetchFailedError,
+    FetchTimeoutError,
+    ScrapeResult,
+    UnsupportedDocumentError,
+)
+from services.url_safety_service import BlockedUrlError, InvalidUrlError
+
+
+def _result() -> ScrapeResult:
+    return ScrapeResult(
+        answer="URL-GROUNDED ANSWER PROMPT...",
+        url="https://example.com/x",
+        title="Title",
+        query="q",
+        content_tokens=42,
+        answer_tokens=123,
+        truncated=False,
+        retrieved_at="2026-06-12T10:30:00Z",
+        metadata={"description": "d", "author": None, "published_date": None},
+    )
+
+
+def _fn(coro):
+    """unwrap a FastMCP-decorated tool to call the underlying coroutine."""
+    return getattr(coro, "fn", coro)
+
+
+class ScrapeUrlToolTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_answer_and_diagnostics(self) -> None:
+        scrape_mock = AsyncMock(return_value=_result())
+        with patch("servers.mcp_server.scrape_url", scrape_mock), patch(
+            "servers.mcp_server._ensure_local_bundle_for_config"
+        ):
+            payload = await _fn(scrape_url_tool)(
+                "https://example.com/x", "q"
+            )
+
+        self.assertEqual(payload["answer"], "URL-GROUNDED ANSWER PROMPT...")
+        self.assertEqual(payload["url"], "https://example.com/x")
+        self.assertEqual(payload["title"], "Title")
+        self.assertEqual(payload["content_tokens"], 42)
+        self.assertEqual(payload["answer_tokens"], 123)
+        self.assertFalse(payload["truncated"])
+        self.assertEqual(payload["retrieved_at"], "2026-06-12T10:30:00Z")
+        self.assertNotIn("metadata", payload)
+
+    async def test_default_max_tokens_passed_through(self) -> None:
+        scrape_mock = AsyncMock(return_value=_result())
+        with patch("servers.mcp_server.scrape_url", scrape_mock), patch(
+            "servers.mcp_server._ensure_local_bundle_for_config"
+        ):
+            await _fn(scrape_url_tool)("https://example.com/x", "q")
+
+        self.assertEqual(scrape_mock.await_args.kwargs["max_tokens"], 4000)
+
+    async def _run_with_exc(self, exc: Exception) -> ValueError:
+        scrape_mock = AsyncMock(side_effect=exc)
+        with patch("servers.mcp_server.scrape_url", scrape_mock), patch(
+            "servers.mcp_server._ensure_local_bundle_for_config"
+        ):
+            try:
+                await _fn(scrape_url_tool)("https://example.com/x", "q")
+            except ValueError as raised:
+                return raised
+        self.fail("expected ValueError")
+
+    async def test_invalid_url_re_raises_with_code_prefix(self) -> None:
+        raised = await self._run_with_exc(InvalidUrlError("bad scheme"))
+        self.assertIn("invalid_url:", str(raised))
+
+    async def test_blocked_url_re_raises_with_code_prefix(self) -> None:
+        raised = await self._run_with_exc(BlockedUrlError("blocked"))
+        self.assertIn("blocked_url:", str(raised))
+
+    async def test_fetch_timeout_re_raises_with_code_prefix(self) -> None:
+        raised = await self._run_with_exc(FetchTimeoutError("slow"))
+        self.assertIn("fetch_timeout:", str(raised))
+
+    async def test_fetch_failed_re_raises_with_code_prefix(self) -> None:
+        raised = await self._run_with_exc(FetchFailedError("dead"))
+        self.assertIn("fetch_failed:", str(raised))
+
+    async def test_unsupported_document_re_raises_with_code_prefix(self) -> None:
+        raised = await self._run_with_exc(UnsupportedDocumentError(".doc"))
+        self.assertIn("unsupported_document:", str(raised))
+
+    async def test_empty_content_re_raises_with_code_prefix(self) -> None:
+        raised = await self._run_with_exc(EmptyContentError("empty"))
+        self.assertIn("empty_content:", str(raised))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scrape_fastapi_mcp_parity.py
+++ b/tests/test_scrape_fastapi_mcp_parity.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from servers.fastapi_server import ScrapeRequest, scrape_endpoint
+from servers.mcp_server import scrape_url_tool
+from services.scrape_service import ScrapeResult
+
+
+def _fn(coro):
+    return getattr(coro, "fn", coro)
+
+
+def _shared_result() -> ScrapeResult:
+    return ScrapeResult(
+        answer="URL-GROUNDED ANSWER PROMPT SHARED",
+        url="https://example.com/x",
+        title="Title",
+        query="q",
+        content_tokens=10,
+        answer_tokens=20,
+        truncated=False,
+        retrieved_at="2026-06-12T10:30:00Z",
+        metadata={"description": "d", "author": None, "published_date": None},
+    )
+
+
+class ScrapeFastApiMcpParityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_both_adapters_return_identical_answer(self) -> None:
+        fastapi_mock = AsyncMock(return_value=_shared_result())
+        mcp_mock = AsyncMock(return_value=_shared_result())
+
+        with patch("servers.fastapi_server.scrape_url", fastapi_mock), patch(
+            "servers.fastapi_server._ensure_local_bundle_for_config",
+            new_callable=AsyncMock,
+        ):
+            fastapi_payload = await scrape_endpoint(
+                ScrapeRequest(url="https://example.com/x", query="q")
+            )
+
+        with patch("servers.mcp_server.scrape_url", mcp_mock), patch(
+            "servers.mcp_server._ensure_local_bundle_for_config"
+        ):
+            mcp_payload = await _fn(scrape_url_tool)("https://example.com/x", "q")
+
+        self.assertEqual(fastapi_payload["answer"], mcp_payload["answer"])
+        self.assertEqual(fastapi_payload["url"], mcp_payload["url"])
+        self.assertEqual(fastapi_payload["title"], mcp_payload["title"])
+        self.assertEqual(
+            fastapi_payload["content_tokens"], mcp_payload["content_tokens"]
+        )
+        self.assertEqual(
+            fastapi_payload["answer_tokens"], mcp_payload["answer_tokens"]
+        )
+        self.assertEqual(fastapi_payload["truncated"], mcp_payload["truncated"])
+        self.assertEqual(
+            fastapi_payload["retrieved_at"], mcp_payload["retrieved_at"]
+        )
+
+    async def test_both_adapters_pass_identical_args_to_service(self) -> None:
+        fastapi_mock = AsyncMock(return_value=_shared_result())
+        mcp_mock = AsyncMock(return_value=_shared_result())
+
+        with patch("servers.fastapi_server.scrape_url", fastapi_mock), patch(
+            "servers.fastapi_server._ensure_local_bundle_for_config",
+            new_callable=AsyncMock,
+        ):
+            await scrape_endpoint(
+                ScrapeRequest(
+                    url="https://example.com/x", query="q", max_tokens=1234
+                )
+            )
+
+        with patch("servers.mcp_server.scrape_url", mcp_mock), patch(
+            "servers.mcp_server._ensure_local_bundle_for_config"
+        ):
+            await _fn(scrape_url_tool)("https://example.com/x", "q", max_tokens=1234)
+
+        fastapi_kwargs = fastapi_mock.await_args.kwargs
+        mcp_kwargs = mcp_mock.await_args.kwargs
+        self.assertEqual(fastapi_kwargs["max_tokens"], mcp_kwargs["max_tokens"])
+        self.assertEqual(
+            fastapi_kwargs["include_metadata"], mcp_kwargs["include_metadata"]
+        )
+        self.assertEqual(
+            fastapi_kwargs["tokenizer_name"], mcp_kwargs["tokenizer_name"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scrape_service.py
+++ b/tests/test_scrape_service.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+from services.scrape_service import (
+    DEFAULT_SCRAPE_MAX_TOKENS,
+    EmptyContentError,
+    FetchFailedError,
+    FetchTimeoutError,
+    SCRAPE_ERROR_MAP,
+    ScrapeResult,
+    UnsupportedDocumentError,
+    scrape_url,
+)
+from services.token_counter_service import token_count
+from services.url_safety_service import BlockedUrlError, InvalidUrlError
+
+
+TOKENIZER = "o200k_base"
+
+
+def _config(**overrides) -> dict:
+    base = {
+        "blocked_domains": [],
+        "pipeline_timeout_seconds": 120.0,
+        "crawl_max_chunk_tokens": 500,
+        "crawl_overlap_tokens": 80,
+        "crawl_bm25_threshold": 1.5,
+        "crawl_bm25_language": "english",
+    }
+    base.update(overrides)
+    return base
+
+
+def _fake_safe_url(url, blocked_domains):
+    return url
+
+
+async def _fake_html_page(*, url, user_query, bm25_threshold, bm25_language):
+    return {
+        "final_url": url,
+        "html": "<html><head><title>Example Article</title></head><body></body></html>",
+        "markdown_raw": (
+            "# Section A\n\nPython asyncio guide explains async tasks.\n\n"
+            "# Section B\n\nBread recipes use flour and yeast.\n\n"
+            "# Section C\n\nAnother paragraph about async."
+        ),
+        "markdown_fit": (
+            "# Section A\n\nPython asyncio guide explains async tasks.\n\n"
+            "# Section C\n\nAnother paragraph about async."
+        ),
+        "metadata": {
+            "title": "Example Article",
+            "description": "A short description",
+            "author": "Alice",
+            "article:published_time": "2026-01-01T00:00:00Z",
+        },
+    }
+
+
+async def _fake_html_redirected(*, url, user_query, bm25_threshold, bm25_language):
+    page = await _fake_html_page(
+        url=url, user_query=user_query, bm25_threshold=bm25_threshold, bm25_language=bm25_language
+    )
+    page["final_url"] = "https://redirected.example/x"
+    return page
+
+
+async def _fake_html_redirect_to_blocked(*, url, user_query, bm25_threshold, bm25_language):
+    page = await _fake_html_page(
+        url=url, user_query=user_query, bm25_threshold=bm25_threshold, bm25_language=bm25_language
+    )
+    page["final_url"] = "https://blocked.example/x"
+    return page
+
+
+async def _fake_html_empty(*, url, user_query, bm25_threshold, bm25_language):
+    return {
+        "final_url": url,
+        "html": "",
+        "markdown_raw": "",
+        "markdown_fit": "",
+        "metadata": {},
+    }
+
+
+def _fake_document(url: str) -> tuple[str, str]:
+    return (
+        "## Page 1\n\nPython asyncio guide explains async tasks.\n\n## Page 2\n\nMore content.",
+        "pdf",
+    )
+
+
+def _fake_document_doc(url: str) -> tuple[str, str]:
+    raise ValueError("legacy .doc files are not supported; use PDF or DOCX")
+
+
+class ScrapeUrlHappyPathTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_grounded_prompt_and_token_counts(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/article",
+                "What does this page say about async?",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertIsInstance(result, ScrapeResult)
+        self.assertIn("URL-GROUNDED ANSWER PROMPT", result.answer)
+        self.assertIn("https://example.com/article", result.answer)
+        self.assertIn("Example Article", result.answer)
+        self.assertIn("What does this page say about async?", result.answer)
+        self.assertEqual(result.url, "https://example.com/article")
+        self.assertEqual(result.title, "Example Article")
+        self.assertEqual(result.query, "What does this page say about async?")
+        self.assertGreater(result.content_tokens, 0)
+        self.assertEqual(result.answer_tokens, token_count(result.answer, TOKENIZER))
+        self.assertFalse(result.truncated)
+
+    async def test_metadata_populated_when_include_metadata_true(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/article",
+                "q",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertEqual(result.metadata["description"], "A short description")
+        self.assertEqual(result.metadata["author"], "Alice")
+        self.assertEqual(result.metadata["published_date"], "2026-01-01T00:00:00Z")
+
+    async def test_metadata_omitted_when_include_metadata_false(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/article",
+                "q",
+                include_metadata=False,
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertIsNone(result.metadata)
+        self.assertNotIn("metadata", result.to_response(include_metadata=False))
+
+    async def test_metadata_partial_fills_with_none(self) -> None:
+        async def _fake_partial(*, url, user_query, bm25_threshold, bm25_language):
+            return {
+                "final_url": url,
+                "html": "<html><head><title>T</title></head></html>",
+                "markdown_raw": "Hello world content about async.",
+                "markdown_fit": "Hello world content about async.",
+                "metadata": {"title": "T", "description": "only this"},
+            }
+
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/x",
+                "q",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_partial,
+            )
+
+        self.assertEqual(result.metadata["description"], "only this")
+        self.assertIsNone(result.metadata["author"])
+        self.assertIsNone(result.metadata["published_date"])
+
+    async def test_retrieved_at_is_utc_iso_with_z_suffix(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/x",
+                "q",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertTrue(result.retrieved_at.endswith("Z"))
+        parsed = datetime.strptime(result.retrieved_at, "%Y-%m-%dT%H:%M:%SZ")
+        self.assertIsNotNone(parsed)
+
+    async def test_preserves_original_query_wording(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/x",
+                "  What does THIS page say about 'Async/Await'?  ",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertEqual(result.query, "What does THIS page say about 'Async/Await'?")
+        self.assertIn("What does THIS page say about 'Async/Await'?", result.answer)
+
+
+class ScrapeUrlBudgetTests(unittest.IsolatedAsyncioTestCase):
+    async def test_truncates_when_total_exceeds_max_tokens(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/x",
+                "async",
+                max_tokens=15,
+                config=_config(crawl_max_chunk_tokens=20, crawl_overlap_tokens=0),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertTrue(result.truncated)
+        self.assertLessEqual(result.content_tokens, 15)
+        self.assertGreater(result.content_tokens, 0)
+
+    async def test_no_truncation_when_budget_covers_all_chunks(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/x",
+                "async",
+                max_tokens=100_000,
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+        self.assertFalse(result.truncated)
+
+    async def test_single_oversized_chunk_is_truncated_at_token_level(self) -> None:
+        long_text = "Python asyncio. " * 200
+
+        async def _fake_long(*, url, user_query, bm25_threshold, bm25_language):
+            return {
+                "final_url": url,
+                "html": "",
+                "markdown_raw": long_text,
+                "markdown_fit": long_text,
+                "metadata": {"title": "Long"},
+            }
+
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/x",
+                "async",
+                max_tokens=20,
+                config=_config(crawl_max_chunk_tokens=4000, crawl_overlap_tokens=0),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_long,
+            )
+
+        self.assertTrue(result.truncated)
+        self.assertEqual(result.content_tokens, 20)
+
+
+class ScrapeUrlValidationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_query_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            await scrape_url(
+                "https://example.com/x",
+                "   ",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                crawl_fn=_fake_html_page,
+            )
+
+    async def test_invalid_url_propagates(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable",
+            side_effect=InvalidUrlError("bad"),
+        ):
+            with self.assertRaises(InvalidUrlError):
+                await scrape_url(
+                    "ftp://example.com/x",
+                    "q",
+                    config=_config(),
+                    tokenizer_name=TOKENIZER,
+                    crawl_fn=_fake_html_page,
+                )
+
+    async def test_blocked_url_propagates(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable",
+            side_effect=BlockedUrlError("nope"),
+        ):
+            with self.assertRaises(BlockedUrlError):
+                await scrape_url(
+                    "https://blocked.example/x",
+                    "q",
+                    config=_config(blocked_domains=["blocked.example"]),
+                    tokenizer_name=TOKENIZER,
+                    crawl_fn=_fake_html_page,
+                )
+
+    async def test_redirect_to_blocked_host_raises(self) -> None:
+        calls = {"n": 0}
+
+        def _safe(url, blocked_domains):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return url
+            raise BlockedUrlError("redirect blocked")
+
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_safe
+        ):
+            with self.assertRaises(BlockedUrlError):
+                await scrape_url(
+                    "https://example.com/x",
+                    "q",
+                    config=_config(blocked_domains=["blocked.example"]),
+                    tokenizer_name=TOKENIZER,
+                    crawl_fn=_fake_html_redirect_to_blocked,
+                )
+
+
+class ScrapeUrlErrorMappingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_markdown_raises_empty_content(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            with self.assertRaises(EmptyContentError):
+                await scrape_url(
+                    "https://example.com/x",
+                    "q",
+                    config=_config(),
+                    tokenizer_name=TOKENIZER,
+                    crawl_fn=_fake_html_empty,
+                )
+
+    async def test_crawl_timeout_raises_fetch_timeout(self) -> None:
+        import asyncio
+
+        async def _slow(*, url, user_query, bm25_threshold, bm25_language):
+            raise asyncio.TimeoutError("slow")
+
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            with self.assertRaises(FetchTimeoutError):
+                await scrape_url(
+                    "https://example.com/x",
+                    "q",
+                    config=_config(),
+                    tokenizer_name=TOKENIZER,
+                    crawl_fn=_slow,
+                )
+
+    async def test_crawl_generic_failure_raises_fetch_failed(self) -> None:
+        async def _boom(*, url, user_query, bm25_threshold, bm25_language):
+            raise RuntimeError("crawler died")
+
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            with self.assertRaises(FetchFailedError):
+                await scrape_url(
+                    "https://example.com/x",
+                    "q",
+                    config=_config(),
+                    tokenizer_name=TOKENIZER,
+                    crawl_fn=_boom,
+                )
+
+    async def test_legacy_doc_raises_unsupported_document(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            with self.assertRaises(UnsupportedDocumentError):
+                await scrape_url(
+                    "https://example.com/file.doc",
+                    "q",
+                    config=_config(),
+                    tokenizer_name=TOKENIZER,
+                    document_fn=_fake_document_doc,
+                )
+
+
+class ScrapeUrlDocumentPathTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pdf_path_returns_grounded_prompt_with_null_metadata(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/file.pdf",
+                "What does the document say about async?",
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                document_fn=_fake_document,
+            )
+
+        self.assertIn("URL-GROUNDED ANSWER PROMPT", result.answer)
+        self.assertEqual(result.url, "https://example.com/file.pdf")
+        self.assertEqual(result.title, "")
+        self.assertEqual(
+            result.metadata,
+            {"description": None, "author": None, "published_date": None},
+        )
+
+    async def test_pdf_path_omits_metadata_when_include_metadata_false(self) -> None:
+        with patch(
+            "services.scrape_service.assert_url_is_fetchable", side_effect=_fake_safe_url
+        ):
+            result = await scrape_url(
+                "https://example.com/file.pdf",
+                "q",
+                include_metadata=False,
+                config=_config(),
+                tokenizer_name=TOKENIZER,
+                document_fn=_fake_document,
+            )
+
+        self.assertIsNone(result.metadata)
+
+
+class ScrapeErrorMapTests(unittest.TestCase):
+    def test_maps_all_known_errors(self) -> None:
+        codes = {value[0] for value in SCRAPE_ERROR_MAP.values()}
+        self.assertEqual(
+            codes,
+            {
+                "invalid_url",
+                "blocked_url",
+                "fetch_timeout",
+                "fetch_failed",
+                "unsupported_document",
+                "empty_content",
+            },
+        )
+
+    def test_default_max_tokens(self) -> None:
+        self.assertEqual(DEFAULT_SCRAPE_MAX_TOKENS, 4000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_url_safety_service.py
+++ b/tests/test_url_safety_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import socket
+import unittest
+from unittest.mock import patch
+
+from services.url_safety_service import (
+    BlockedUrlError,
+    InvalidUrlError,
+    assert_url_is_fetchable,
+    enforce_blocked_domains,
+    resolve_and_check_public,
+    validate_public_url,
+)
+
+
+def _addrinfo(ip: str, *, family: int = socket.AF_INET) -> tuple:
+    port = 0
+    if family == socket.AF_INET6:
+        sockaddr = (ip, port, 0, 0)
+    else:
+        sockaddr = (ip, port)
+    return (family, socket.SOCK_STREAM, 6, "", sockaddr)
+
+
+class ValidatePublicUrlTests(unittest.TestCase):
+    def test_accepts_https_url(self) -> None:
+        self.assertEqual(
+            validate_public_url("https://example.com/a"),
+            "https://example.com/a",
+        )
+
+    def test_accepts_http_url(self) -> None:
+        self.assertEqual(
+            validate_public_url("http://example.com"),
+            "http://example.com",
+        )
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        self.assertEqual(
+            validate_public_url("  https://example.com/a  "),
+            "https://example.com/a",
+        )
+
+    def test_rejects_empty_string(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            validate_public_url("")
+
+    def test_rejects_file_scheme(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            validate_public_url("file:///etc/passwd")
+
+    def test_rejects_ftp_scheme(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            validate_public_url("ftp://example.com/x")
+
+    def test_rejects_javascript_scheme(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            validate_public_url("javascript:alert(1)")
+
+    def test_rejects_userinfo(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            validate_public_url("https://user:password@example.com/x")
+
+    def test_rejects_missing_host(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            validate_public_url("https:///x")
+
+    def test_rejects_ipv4_loopback_literal(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            validate_public_url("http://127.0.0.1/x")
+
+    def test_rejects_ipv6_loopback_literal(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            validate_public_url("http://[::1]/x")
+
+    def test_rejects_private_ipv4_literal(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            validate_public_url("http://10.0.0.1/x")
+        with self.assertRaises(BlockedUrlError):
+            validate_public_url("http://192.168.1.1/x")
+
+    def test_rejects_link_local_ipv4_literal(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            validate_public_url("http://169.254.0.1/x")
+
+    def test_rejects_multicast_ipv4_literal(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            validate_public_url("http://224.0.0.1/x")
+
+
+class ResolveAndCheckPublicTests(unittest.TestCase):
+    def test_accepts_public_ipv4(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo",
+            return_value=[_addrinfo("93.184.216.34")],
+        ):
+            self.assertEqual(
+                resolve_and_check_public("example.com"),
+                ["93.184.216.34"],
+            )
+
+    def test_rejects_when_any_resolved_address_is_private(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo",
+            return_value=[
+                _addrinfo("93.184.216.34"),
+                _addrinfo("10.0.0.1"),
+            ],
+        ):
+            with self.assertRaises(BlockedUrlError):
+                resolve_and_check_public("example.com")
+
+    def test_rejects_when_resolved_to_loopback_only(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo",
+            return_value=[_addrinfo("127.0.0.1")],
+        ):
+            with self.assertRaises(BlockedUrlError):
+                resolve_and_check_public("localhost")
+
+    def test_propagates_dns_failure_as_invalid_url(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo",
+            side_effect=socket.gaierror("not found"),
+        ):
+            with self.assertRaises(InvalidUrlError):
+                resolve_and_check_public("nope.invalid")
+
+
+class EnforceBlockedDomainsTests(unittest.TestCase):
+    def test_rejects_exact_host_match(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            enforce_blocked_domains(
+                "https://blocked.example/x",
+                ["blocked.example"],
+            )
+
+    def test_rejects_subdomain_of_blocked_host(self) -> None:
+        with self.assertRaises(BlockedUrlError):
+            enforce_blocked_domains(
+                "https://news.blocked.example/x",
+                ["blocked.example"],
+            )
+
+    def test_allows_unrelated_host(self) -> None:
+        enforce_blocked_domains(
+            "https://allowed.example/x",
+            ["blocked.example"],
+        )
+
+
+class AssertUrlIsFetchableTests(unittest.TestCase):
+    def test_happy_path_with_public_dns(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo",
+            return_value=[_addrinfo("93.184.216.34")],
+        ):
+            self.assertEqual(
+                assert_url_is_fetchable(
+                    "https://example.com/a",
+                    blocked_domains=[],
+                ),
+                "https://example.com/a",
+            )
+
+    def test_blocked_domain_short_circuits_before_dns(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo"
+        ) as getaddrinfo:
+            with self.assertRaises(BlockedUrlError):
+                assert_url_is_fetchable(
+                    "https://blocked.example/x",
+                    blocked_domains=["blocked.example"],
+                )
+            getaddrinfo.assert_not_called()
+
+    def test_invalid_scheme_short_circuits(self) -> None:
+        with self.assertRaises(InvalidUrlError):
+            assert_url_is_fetchable("ftp://example.com/x", blocked_domains=[])
+
+    def test_private_resolved_address_is_blocked(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo",
+            return_value=[_addrinfo("10.0.0.1")],
+        ):
+            with self.assertRaises(BlockedUrlError):
+                assert_url_is_fetchable(
+                    "https://internal.example/x",
+                    blocked_domains=[],
+                )
+
+    def test_ip_literal_skips_dns_resolution(self) -> None:
+        with patch(
+            "services.url_safety_service.socket.getaddrinfo"
+        ) as getaddrinfo:
+            self.assertEqual(
+                assert_url_is_fetchable(
+                    "https://93.184.216.34/a",
+                    blocked_domains=[],
+                ),
+                "https://93.184.216.34/a",
+            )
+            getaddrinfo.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  - Crawls the page through the existing Crawl4AI path (with PDF/DOCX support), chunks markdown, ranks chunks against the query with BM25, selects under a
  token budget, and returns a URL-grounded answer prompt.
  - The grounded prompt builder is extracted into services/grounded_prompt_service.py and is now shared with /research so the two flows cannot drift.
  - URL safety (scheme allowlist, no credentials, IP literal rejection, DNS rebinding mitigation by rejecting any non-public resolved address,
  blocked_domains enforcement on the initial URL and the final URL after redirects) lives in services/url_safety_service.py and is shared by FastAPI and
  MCP.
  - Stable error codes per the issue spec: invalid_url (400), blocked_url (403), unsupported_document (415), empty_content (422), fetch_failed (502),
  fetch_timeout (504). MCP re-raises ValueError prefixed with the code.
  - No new runtime dependencies. Metadata extraction reads from the Crawl4AI metadata dict with a small regex fallback over the page HTML.

  ## Tests

  - 78 new unit and integration tests across the prompt builder, URL safety, scrape service, FastAPI endpoint, MCP tool, and FastAPI/MCP parity.
  - Existing test suite continues to pass (161 tests total).
  - Smoke tested on the Docker compose stack (fastapi + searxng): /scrape happy path, SSRF rejection, truncation, and /research after the prompt builder
  refactor.

  ## Notes

  - The first version uses BM25 ranking. Hybrid ranking is acceptable as a follow-up; staying on BM25 keeps latency low for the "URL already known" use case
   and avoids bootstrapping the embedder on every scrape request.
  - Crawl4AI exposes the initial URL and the final URL after redirects, not every intermediate hop. The safety check runs on both; the README notes the
  limit and suggests an egress proxy for stricter handling if needed.