### PR TITLE
Add get_current_datetime MCP tool and FastAPI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,21 @@ Stop and remove the containers later with:
 docker compose -f "https://github.com/MarcellM01/TinySearch.git#main:compose.quickstart.yaml" down
 ```
 
-TinySearch exposes two MCP tools:
+TinySearch exposes three MCP tools:
 
 ```text
+get_current_datetime()
 research(query)
 scrape_url(url, query)
 ```
 
-Pass the user's question as-is. Use `research` first when you need to discover
-relevant URLs; it searches, crawls, reranks, and returns the grounded prompt in
-`answer`. Use `scrape_url` after the user provides a URL or `research` already
-identified the page to inspect; it applies the same ranking with the server's
-default token budget and returns the grounded prompt in `answer`.
+Call `get_current_datetime()` first for time-sensitive questions or before
+adding year/month/day context to a research query. Pass the user's question
+as-is. Use `research` first when you need to discover relevant URLs; it searches,
+crawls, reranks, and returns the grounded prompt in `answer`. Use `scrape_url`
+after the user provides a URL or `research` already identified the page to
+inspect; it applies the same ranking with the server's default token budget and
+returns the grounded prompt in `answer`.
 
 ## Community
 
@@ -281,6 +284,7 @@ uvicorn servers.fastapi_server:app --reload
 Endpoints:
 
 - `GET /health`
+- `GET /current_datetime`
 - `GET /web_search?query=...`
 - `POST /site_crawl`
 - `POST /scrape`

--- a/agentic_coding_templates/global-rules-recommended.md
+++ b/agentic_coding_templates/global-rules-recommended.md
@@ -1,8 +1,14 @@
 ## MCP Knowledge Pack (tinysearch)
 
-This environment uses the **tinysearch** MCP server. It exposes **two** tools.
+This environment uses the **tinysearch** MCP server. It exposes **three** tools.
 
 ### Available tools
+
+**`get_current_datetime()`**
+
+- **Input:** none.
+- **Output:** `{"date_utc", "time_utc"}` in UTC.
+- **When to use:** before time-sensitive research, relative-date questions (`latest`, `this year`, `last month`), or when you need to add year/month/day context to a `research` query.
 
 **`research(query)`**
 
@@ -16,7 +22,7 @@ This environment uses the **tinysearch** MCP server. It exposes **two** tools.
 - **Output:** `{"answer", "url", "title", "truncated", "retrieved_at"}`. The `answer` is a **URL-grounded prompt** (not a finished article): it contains the page content most relevant to `query`. **Your job** is to answer from that prompt and **cite the returned `url`**.
 - **Errors:** failures surface as `ValueError` with stable code prefixes: `invalid_url`, `blocked_url`, `unsupported_document`, `empty_content`, `fetch_failed`, `fetch_timeout`.
 
-There is **no** `access_site`, `search_web`, `lite_*`, or `mode` / `max_results` on this server. Use **`research(query)`** for discovery and **`scrape_url(url, query)`** when you already know the page to read.
+There is **no** `access_site`, `search_web`, `lite_*`, or `mode` / `max_results` on this server. Use **`get_current_datetime()`** for current UTC time, **`research(query)`** for discovery, and **`scrape_url(url, query)`** when you already know the page to read.
 
 ---
 
@@ -35,6 +41,11 @@ This order is mandatory. Reversing it (or only doing the MCP half) mis-describes
 - “Where is X configured / called / defined?”
 - “Which version / provider / endpoint does the code target?”
 - Anything answerable from files in the repo.
+
+#### When to use `get_current_datetime()`
+Use it before **`research(query)`** when:
+- the question is time-sensitive or uses relative dates
+- you need the current year/month/day to orient a search query
 
 #### When to use `research(query)`
 Use it when you need **up-to-date external facts** and primary sources, and you do **not** yet know which page to read:
@@ -60,12 +71,13 @@ Pass the user’s question in **`query`** unchanged. Cite the **`url`** returned
 
 ---
 
-### Strategy with two tools
+### Strategy with three tools
 
-1. **Discovery first:** if you do not yet know which page to read, call **`research(query)`** once with a clear question aligned to the user’s goal.
-2. **Known URL:** if the user gave a URL (or one is already identified), call **`scrape_url(url, query)`** instead of re-searching for the same page.
-3. **Answer from `answer`**: synthesize the user’s reply from the grounded prompt; pull **URLs** from the prompt (or the `url` field for `scrape_url`) for citations.
-4. If the prompt is thin on one angle, **refine `query`** and call the same tool again with a narrower follow-up, or switch tools only when the gap is “find a page” (`research`) vs “read this page” (`scrape_url`).
+1. **Time check:** for time-sensitive or relative-date questions, call **`get_current_datetime()`** first unless you already know the current UTC date and time.
+2. **Discovery first:** if you do not yet know which page to read, call **`research(query)`** once with a clear question aligned to the user’s goal.
+3. **Known URL:** if the user gave a URL (or one is already identified), call **`scrape_url(url, query)`** instead of re-searching for the same page.
+4. **Answer from `answer`**: synthesize the user’s reply from the grounded prompt; pull **URLs** from the prompt (or the `url` field for `scrape_url`) for citations.
+5. If the prompt is thin on one angle, **refine `query`** and call the same tool again with a narrower follow-up, or switch tools only when the gap is “find a page” (`research`) vs “read this page” (`scrape_url`).
 
 #### If the user gave an exact URL
 Call **`scrape_url(url, query)`** with the pasted URL and the user’s question as `query`. Do not route URL-only fetches through **`research(query)`** unless you also need broader discovery beyond that page.

--- a/servers/fastapi_server.py
+++ b/servers/fastapi_server.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, HttpUrl
 
 from pipelines.agentic_research import agentic_run
+from services.current_datetime_service import current_datetime_payload
 from services.embedding_service import normalize_embedding_backend
 from services.research_config_service import (
     config_trace_path,
@@ -128,6 +129,11 @@ class ResearchRequest(BaseModel):
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/current_datetime")
+async def current_datetime_endpoint() -> dict[str, str]:
+    return current_datetime_payload()
 
 
 @app.post("/web_search")

--- a/servers/mcp_server.py
+++ b/servers/mcp_server.py
@@ -17,6 +17,7 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from pipelines.agentic_research import agentic_run
+from services.current_datetime_service import current_datetime_payload
 from services.embedding_service import normalize_embedding_backend
 from services.research_config_service import (
     config_trace_path,
@@ -165,14 +166,20 @@ async def _run_streamable_http_combined_async() -> None:
 
 
 MCP_INSTRUCTIONS = """
-This MCP server exposes two high-level web tools:
+This MCP server exposes three tools:
 
-1. research(query)
-2. scrape_url(url, query)
+1. get_current_datetime()
+2. research(query)
+3. scrape_url(url, query)
+
+Before calling research for time-sensitive questions, or if you need to add
+year/month/day context to a query, call get_current_datetime() first to orient
+on the current date and time (UTC).
 
 Pass the user's question as-is in query. Do not rewrite, correct spelling,
 expand abbreviations, add dates, add missing context, simplify, translate, or
-otherwise improve the user's wording before calling either tool.
+otherwise improve the user's wording before calling either tool, unless temporal
+augmentation is genuinely needed after checking get_current_datetime().
 
 Use research first when you need to discover relevant URLs. It searches the web
 through the configured backend (SearXNG by default, with a DuckDuckGo fallback),
@@ -231,13 +238,30 @@ mcp = FastMCP(
 
 
 @mcp.tool(
+    name="get_current_datetime",
+    title="Get Current Datetime",
+    description=(
+        "Return the current date and time in UTC. Call this first for "
+        "time-sensitive questions, relative dates such as latest, this year, "
+        "or last month, or before adding year/month/day context to a research "
+        "query."
+    ),
+)
+async def get_current_datetime_tool() -> dict[str, str]:
+    _log("get_current_datetime called")
+    return current_datetime_payload()
+
+
+@mcp.tool(
     name="research",
     title="Research",
     description=(
         "Discover relevant URLs for the user's question, crawl ranked pages, "
         "and return a search-grounded answer prompt. Use this first when you "
         "need to find sources. Input schema has exactly one field: query. "
-        "Pass the user's question as-is."
+        "Pass the user's question as-is. For time-sensitive or relative-date "
+        "questions, call get_current_datetime() first unless you already "
+        "know the current date and time."
     ),
 )
 async def research(

--- a/services/current_datetime_service.py
+++ b/services/current_datetime_service.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def current_datetime_payload() -> dict[str, str]:
+    now = datetime.now(UTC).replace(microsecond=0)
+    return {
+        "date_utc": now.date().isoformat(),
+        "time_utc": now.strftime("%H:%M:%S"),
+    }

--- a/tests/test_current_datetime_service.py
+++ b/tests/test_current_datetime_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import re
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from services.current_datetime_service import current_datetime_payload
+
+
+class CurrentDatetimeServiceTests(unittest.TestCase):
+    def test_payload_shape(self) -> None:
+        payload = current_datetime_payload()
+        self.assertEqual(set(payload), {"date_utc", "time_utc"})
+
+    def test_payload_uses_iso_formats(self) -> None:
+        fixed = datetime(2026, 6, 28, 8, 10, 0, tzinfo=UTC)
+        with patch("services.current_datetime_service.datetime") as mock_datetime:
+            mock_datetime.now.return_value = fixed
+            payload = current_datetime_payload()
+
+        self.assertEqual(payload["date_utc"], "2026-06-28")
+        self.assertEqual(payload["time_utc"], "08:10:00")
+        self.assertRegex(payload["date_utc"], re.compile(r"^\d{4}-\d{2}-\d{2}$"))
+        self.assertRegex(payload["time_utc"], re.compile(r"^\d{2}:\d{2}:\d{2}$"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fastapi_current_datetime.py
+++ b/tests/test_fastapi_current_datetime.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from servers.fastapi_server import current_datetime_endpoint
+
+
+class FastApiCurrentDatetimeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_current_datetime_payload(self) -> None:
+        with patch(
+            "servers.fastapi_server.current_datetime_payload",
+            return_value={
+                "date_utc": "2026-06-28",
+                "time_utc": "08:10:00",
+            },
+        ):
+            payload = await current_datetime_endpoint()
+
+        self.assertEqual(payload["date_utc"], "2026-06-28")
+        self.assertEqual(payload["time_utc"], "08:10:00")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_current_datetime.py
+++ b/tests/test_mcp_current_datetime.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import unittest
+from inspect import signature
+from unittest.mock import patch
+
+from servers.mcp_server import get_current_datetime_tool
+from servers.fastapi_server import current_datetime_endpoint
+
+
+def _fn(coro):
+    return getattr(coro, "fn", coro)
+
+
+class McpCurrentDatetimeTests(unittest.IsolatedAsyncioTestCase):
+    def test_mcp_signature_has_no_parameters(self) -> None:
+        self.assertEqual(list(signature(_fn(get_current_datetime_tool)).parameters), [])
+
+    async def test_returns_current_datetime_payload(self) -> None:
+        with patch(
+            "servers.mcp_server.current_datetime_payload",
+            return_value={
+                "date_utc": "2026-06-28",
+                "time_utc": "08:10:00",
+            },
+        ):
+            payload = await _fn(get_current_datetime_tool)()
+
+        self.assertEqual(payload["date_utc"], "2026-06-28")
+        self.assertEqual(payload["time_utc"], "08:10:00")
+
+    async def test_mcp_and_fastapi_return_same_payload(self) -> None:
+        with patch(
+            "servers.mcp_server.current_datetime_payload",
+            return_value={
+                "date_utc": "2026-06-28",
+                "time_utc": "08:10:00",
+            },
+        ), patch(
+            "servers.fastapi_server.current_datetime_payload",
+            return_value={
+                "date_utc": "2026-06-28",
+                "time_utc": "08:10:00",
+            },
+        ):
+            mcp_payload = await _fn(get_current_datetime_tool)()
+            fastapi_payload = await current_datetime_endpoint()
+
+        self.assertEqual(mcp_payload, fastapi_payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose an on-demand UTC date/time tool so agents can orient on the current date before time-sensitive research, working reliably over stdio where MCP instructions are only sent at initialize. Adds a shared service, MCP tool, GET /current_datetime endpoint, tests, and docs.