### PR TITLE
Harden scraping and parsing against ReDoS and bump vulnerable dependendencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Unit tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-crawl4ai==0.8.6
+crawl4ai==0.9.0
 tiktoken==0.12.0
 rank-bm25==0.2.2
-pypdf==6.10.2
+pypdf==6.13.3
 python-docx==1.2.0
 fastapi==0.136.1
 uvicorn==0.46.0

--- a/services/scrape_service.py
+++ b/services/scrape_service.py
@@ -9,12 +9,12 @@ return a grounded answer prompt plus token accounting.
 from __future__ import annotations
 
 import asyncio
-import re
 import socket
 import urllib.error
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
+from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -91,24 +91,49 @@ class ScrapeResult:
         return payload
 
 
-_TITLE_RE = re.compile(r"<title[^>]*>([^<]+)</title>", re.IGNORECASE)
-_META_NAME_FIRST_RE = re.compile(
-    r'<meta\s+[^>]*?(?:name|property)\s*=\s*["\']([^"\']+)["\'][^>]*?content\s*=\s*["\']([^"\']*)["\'][^>]*>',
-    re.IGNORECASE,
-)
-_META_CONTENT_FIRST_RE = re.compile(
-    r'<meta\s+[^>]*?content\s*=\s*["\']([^"\']*)["\'][^>]*?(?:name|property)\s*=\s*["\']([^"\']+)["\'][^>]*>',
-    re.IGNORECASE,
-)
+class _HtmlMetaParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.meta: dict[str, str] = {}
+        self.title_parts: list[str] = []
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        lowered = tag.lower()
+        if lowered == "title":
+            self._in_title = True
+            return
+        if lowered != "meta":
+            return
+        attr_map = {key.lower(): (value or "") for key, value in attrs}
+        key = (attr_map.get("name") or attr_map.get("property") or "").strip().lower()
+        value = attr_map.get("content", "").strip()
+        if key and value:
+            self.meta.setdefault(key, value)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+
+
+def _parse_html_meta_and_title(html: str) -> tuple[dict[str, str], str]:
+    parser = _HtmlMetaParser()
+    try:
+        parser.feed(html or "")
+        parser.close()
+    except Exception:
+        return {}, ""
+    title = "".join(parser.title_parts).strip()
+    return parser.meta, title
 
 
 def _scan_html_meta(html: str) -> dict[str, str]:
-    found: dict[str, str] = {}
-    for key, value in _META_NAME_FIRST_RE.findall(html or ""):
-        found.setdefault(key.strip().lower(), value.strip())
-    for value, key in _META_CONTENT_FIRST_RE.findall(html or ""):
-        found.setdefault(key.strip().lower(), value.strip())
-    return found
+    meta, _ = _parse_html_meta_and_title(html)
+    return meta
 
 
 def _coerce_str(value: Any) -> str:
@@ -123,10 +148,8 @@ def _extract_title(crawl_metadata: dict[str, Any], html: str) -> str:
     title = _coerce_str(crawl_metadata.get("title"))
     if title:
         return title
-    match = _TITLE_RE.search(html or "")
-    if match:
-        return match.group(1).strip()
-    return ""
+    _, html_title = _parse_html_meta_and_title(html)
+    return html_title
 
 
 def _extract_metadata(

--- a/services/text_chunking_service.py
+++ b/services/text_chunking_service.py
@@ -90,9 +90,9 @@ def chunk_text(
         if not block:
             continue
 
-        heading_match = re.match(r"^(#{1,6})\s+(.+)$", block)
-        if heading_match:
-            current_heading = heading_match.group(2).strip()
+        heading = _parse_markdown_heading(block)
+        if heading is not None:
+            current_heading = heading
 
         block_tokens = len(encoding.encode(block))
 
@@ -114,3 +114,17 @@ def chunk_text(
     return chunks
 
 chunk_markdown = chunk_text
+
+
+def _parse_markdown_heading(block: str) -> str | None:
+    if not block or block[0] != "#":
+        return None
+    marker_count = 0
+    while marker_count < len(block) and block[marker_count] == "#":
+        marker_count += 1
+    if marker_count < 1 or marker_count > 6:
+        return None
+    if marker_count >= len(block) or not block[marker_count].isspace():
+        return None
+    heading = block[marker_count:].strip()
+    return heading or None

--- a/services/token_counter_service.py
+++ b/services/token_counter_service.py
@@ -101,7 +101,17 @@ def _resolve_huggingface_tokenizer(name: str):
     return HuggingFaceTokenizerAdapter(tokenizer)
 
 
+def _looks_like_tokenizer_path(name: str) -> bool:
+    if name.startswith(("/", "./", "../")):
+        return True
+    if "/" in name or "\\" in name:
+        return True
+    return name.lower().endswith(".json")
+
+
 def _resolve_tokenizers_json(name: str):
+    if not _looks_like_tokenizer_path(name):
+        return None
     try:
         from tokenizers import Tokenizer
     except Exception:

--- a/tests/test_scrape_html_meta.py
+++ b/tests/test_scrape_html_meta.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import unittest
+
+from services.scrape_service import (
+    _extract_metadata,
+    _extract_title,
+    _scan_html_meta,
+)
+
+
+class ScrapeHtmlMetaParserTests(unittest.TestCase):
+    def test_extracts_meta_name_before_content(self) -> None:
+        html = (
+            '<html><head><meta name="description" content="A short description">'
+            '<meta property="og:description" content="OG description"></head></html>'
+        )
+        meta = _scan_html_meta(html)
+        self.assertEqual(meta["description"], "A short description")
+        self.assertEqual(meta["og:description"], "OG description")
+
+    def test_extracts_meta_content_before_name(self) -> None:
+        html = (
+            '<html><head><meta content="Alice" name="author">'
+            '<meta content="2026-01-01" property="article:published_time"></head></html>'
+        )
+        meta = _scan_html_meta(html)
+        self.assertEqual(meta["author"], "Alice")
+        self.assertEqual(meta["article:published_time"], "2026-01-01")
+
+    def test_extract_title_from_html_when_metadata_missing(self) -> None:
+        html = "<html><head><title>Example Article</title></head></html>"
+        title = _extract_title({}, html)
+        self.assertEqual(title, "Example Article")
+
+    def test_extract_metadata_prefers_crawl_metadata_then_html(self) -> None:
+        html = '<html><head><meta name="description" content="From HTML"></head></html>'
+        metadata = _extract_metadata({"title": "Crawl Title"}, html)
+        self.assertEqual(metadata["description"], "From HTML")
+
+        metadata_with_crawl = _extract_metadata(
+            {"description": "From crawl", "author": "Bob"},
+            html,
+        )
+        self.assertEqual(metadata_with_crawl["description"], "From crawl")
+        self.assertEqual(metadata_with_crawl["author"], "Bob")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_text_chunking_service.py
+++ b/tests/test_text_chunking_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from services.text_chunking_service import truncate_text_to_max_tokens
+from services.text_chunking_service import _parse_markdown_heading, chunk_text, truncate_text_to_max_tokens
 
 
 class TruncateTextToMaxTokensTests(unittest.TestCase):
@@ -20,6 +20,21 @@ class TruncateTextToMaxTokensTests(unittest.TestCase):
         out = truncate_text_to_max_tokens(text, 12, "o200k_base")
         self.assertLess(len(out), len(text))
         self.assertTrue(out.strip())
+
+    def test_parse_markdown_heading(self) -> None:
+        self.assertEqual(_parse_markdown_heading("# Intro"), "Intro")
+        self.assertEqual(_parse_markdown_heading("###### Deep"), "Deep")
+        self.assertIsNone(_parse_markdown_heading("not a heading"))
+        self.assertIsNone(_parse_markdown_heading("####### Too many"))
+
+    def test_chunk_text_preserves_heading_metadata(self) -> None:
+        chunks = chunk_text(
+            "# Only Section\n\nBody text.",
+            max_chunk_tokens=500,
+            encoding_name="o200k_base",
+        )
+        self.assertEqual(chunks[0]["heading"], "Only Section")
+        self.assertIn("Body text.", chunks[0]["text"])
 
 
 if __name__ == "__main__":

--- a/tests/test_token_counter_service.py
+++ b/tests/test_token_counter_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from services.token_counter_service import (
+    _looks_like_tokenizer_path,
+    _resolve_tokenizers_json,
+    resolve_tokenizer,
+)
+
+
+class TokenizerPathGuardTests(unittest.TestCase):
+    def test_plain_encoding_names_are_not_paths(self) -> None:
+        self.assertFalse(_looks_like_tokenizer_path("o200k_base"))
+        self.assertFalse(_looks_like_tokenizer_path("text-embedding-3-small"))
+
+    def test_path_like_names_are_detected(self) -> None:
+        self.assertTrue(_looks_like_tokenizer_path("/tmp/tokenizer.json"))
+        self.assertTrue(_looks_like_tokenizer_path("./models/tokenizer.json"))
+        self.assertTrue(_looks_like_tokenizer_path("models/tokenizer.json"))
+
+    def test_non_path_name_does_not_probe_filesystem(self) -> None:
+        with patch("services.token_counter_service.Path") as path_cls:
+            self.assertIsNone(_resolve_tokenizers_json("o200k_base"))
+        path_cls.assert_not_called()
+
+    def test_path_like_name_loads_tokenizer_json(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tokenizer_path = Path(td) / "tokenizer.json"
+            tokenizer_path.write_text(
+                '{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":null,"post_processor":null,"decoder":null,"model":{"type":"BPE","dropout":null,"unk_token":null,"continuing_subword_prefix":null,"end_of_word_suffix":null,"fuse_unk":false,"byte_fallback":false,"vocab":{},"merges":[]}}',
+                encoding="utf-8",
+            )
+            adapter = _resolve_tokenizers_json(str(tokenizer_path))
+            self.assertIsNotNone(adapter)
+            self.assertEqual(adapter.encode("hi"), [])
+
+    def test_resolve_tokenizer_still_uses_tiktoken_for_o200k_base(self) -> None:
+        tokenizer = resolve_tokenizer("o200k_base")
+        self.assertGreater(len(tokenizer.encode("hello")), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replace regex-based HTML meta/title extraction and markdown heading parsing with safer parsers, guard tokenizer path resolution, tighten CI permissions, and update crawl4ai and pypdf.