### PR TITLE
Limit dense chunk ranking with BM25 prefilter

### DIFF
--- a/configs/research_config.json
+++ b/configs/research_config.json
@@ -9,6 +9,8 @@
   "chunk_rank_oversample": 3,
   "chunk_dedupe_jaccard_threshold": 0.92,
   "chunk_max_per_source_url": 4,
+  "chunk_dense_bm25_prefilter_per_source": 16,
+  "chunk_dense_bm25_prefilter_max_total": 128,
   "max_concurrent_crawls": 5,
   "max_concurrent_embedding_calls": 4,
   "pipeline_timeout_seconds": 120.0,

--- a/pipelines/agentic_research.py
+++ b/pipelines/agentic_research.py
@@ -143,6 +143,8 @@ async def _rank(
     dense_query_prefix: str,
     dense_document_prefix: str,
     dense_document_embed_batch_size: int | None,
+    dense_bm25_prefilter_per_source: int | None = None,
+    dense_bm25_prefilter_max_total: int | None = None,
 ) -> list[dict[str, Any]]:
     return await rank_chunks_hybrid(
         query,
@@ -154,6 +156,8 @@ async def _rank(
         dense_query_prefix=dense_query_prefix,
         dense_document_prefix=dense_document_prefix,
         dense_document_embed_batch_size=dense_document_embed_batch_size,
+        dense_bm25_prefilter_per_source=dense_bm25_prefilter_per_source,
+        dense_bm25_prefilter_max_total=dense_bm25_prefilter_max_total,
         semaphore=semaphore,
         timeout_seconds=timeout_seconds,
         max_timeout_retries=timeout_retries,
@@ -192,6 +196,8 @@ async def agentic_run(
     dense_query_prefix: str = DEFAULT_DENSE_QUERY_PREFIX,
     dense_document_prefix: str = DEFAULT_DENSE_DOCUMENT_PREFIX,
     dense_document_embed_batch_size: int | None = 32,
+    chunk_dense_bm25_prefilter_per_source: int | None = 16,
+    chunk_dense_bm25_prefilter_max_total: int | None = 128,
     blocked_domains: Sequence[str] | None = None,
     trace_path: str | Path | None = None,
     progress_callback: ProgressCallback | None = None,
@@ -280,12 +286,15 @@ async def agentic_run(
             "dense_query_prefix": dense_query_prefix,
             "dense_document_prefix": dense_document_prefix,
             "dense_document_embed_batch_size": dense_document_embed_batch_size,
+            "chunk_dense_bm25_prefilter_per_source": chunk_dense_bm25_prefilter_per_source,
+            "chunk_dense_bm25_prefilter_max_total": chunk_dense_bm25_prefilter_max_total,
             "blocked_domains": list(blocked_domains or []),
         },
         "web_search": [],
         "ranked_search_results": [],
         "crawl_results": [],
         "ranked_chunk_pool": [],
+        "chunk_ranking": {},
         "final_prompt": "",
         "crawl_errors": [],
     }
@@ -439,7 +448,35 @@ async def agentic_run(
                 1,
                 min(len(chunk_pool), chunk_max_results_to_keep * oversample),
             )
-            await emit("chunk_embed_ranking", chunks=len(chunk_pool), rank_pool_cap=chunk_rank_pool_cap)
+            prefilter_enabled = (
+                chunk_dense_bm25_prefilter_per_source is not None
+                and chunk_dense_bm25_prefilter_per_source > 0
+                and chunk_dense_bm25_prefilter_max_total is not None
+                and chunk_dense_bm25_prefilter_max_total > 0
+                and len(chunk_pool) > chunk_dense_bm25_prefilter_max_total
+            )
+            dense_candidates_estimate = (
+                min(
+                    len(chunk_pool),
+                    len({str(chunk.get("source_url") or "") for chunk in chunk_pool})
+                    * chunk_dense_bm25_prefilter_per_source,
+                    chunk_dense_bm25_prefilter_max_total,
+                )
+                if prefilter_enabled
+                else len(chunk_pool)
+            )
+            trace["chunk_ranking"] = {
+                "chunks_total": len(chunk_pool),
+                "dense_candidates": dense_candidates_estimate,
+                "rank_pool_cap": chunk_rank_pool_cap,
+            }
+            await emit(
+                "chunk_embed_ranking",
+                chunks=len(chunk_pool),
+                chunks_total=len(chunk_pool),
+                dense_candidates=dense_candidates_estimate,
+                rank_pool_cap=chunk_rank_pool_cap,
+            )
             ranked_wide = await _rank(
                 query=query,
                 chunks=chunk_pool,
@@ -453,6 +490,8 @@ async def agentic_run(
                 dense_query_prefix=dense_query_prefix,
                 dense_document_prefix=dense_document_prefix,
                 dense_document_embed_batch_size=dense_document_embed_batch_size,
+                dense_bm25_prefilter_per_source=chunk_dense_bm25_prefilter_per_source,
+                dense_bm25_prefilter_max_total=chunk_dense_bm25_prefilter_max_total,
             )
             ranked_chunk_pool = select_chunks_with_quota_and_fill(
                 ranked_wide,
@@ -476,6 +515,7 @@ async def agentic_run(
                 "pages_indexed",
                 urls_read=len(ranked_search_chunks),
                 chunks_extracted=len(chunk_pool),
+                dense_candidates=dense_candidates_estimate,
                 chunks_in_prompt=len(ranked_chunk_pool),
                 crawl_errors_count=len(crawl_errors),
             )

--- a/servers/fastapi_server.py
+++ b/servers/fastapi_server.py
@@ -105,6 +105,12 @@ class ResearchRequest(BaseModel):
         default=None, ge=0.0, le=1.0
     )
     chunk_max_per_source_url: int | None = Field(default=None, ge=0, le=500)
+    chunk_dense_bm25_prefilter_per_source: int | None = Field(
+        default=None, ge=0, le=500
+    )
+    chunk_dense_bm25_prefilter_max_total: int | None = Field(
+        default=None, ge=0, le=10_000
+    )
     max_concurrent_crawls: int | None = Field(default=None, ge=1, le=20)
     max_concurrent_embedding_calls: int | None = Field(default=None, ge=1, le=20)
     pipeline_timeout_seconds: float | None = Field(default=None, gt=0)

--- a/services/hybrid_embed_search_service.py
+++ b/services/hybrid_embed_search_service.py
@@ -57,6 +57,47 @@ def _rank_by_score(scores: Sequence[float]) -> dict[int, int]:
     }
 
 
+def _source_url(chunk: dict[str, Any]) -> str:
+    return str(chunk.get("source_url") or "")
+
+
+def _select_dense_candidate_indices(
+    bm25_scores: Sequence[float],
+    chunks: Sequence[dict[str, Any]],
+    *,
+    per_source: int | None,
+    max_total: int | None,
+) -> list[int]:
+    if per_source is None or per_source <= 0:
+        return list(range(len(chunks)))
+    if max_total is not None and max_total <= 0:
+        return list(range(len(chunks)))
+    if max_total is not None and len(chunks) <= max_total:
+        return list(range(len(chunks)))
+
+    grouped: dict[str, list[int]] = {}
+    for idx, chunk in enumerate(chunks):
+        grouped.setdefault(_source_url(chunk), []).append(idx)
+
+    selected: set[int] = set()
+    for indices in grouped.values():
+        ranked_source = sorted(
+            indices,
+            key=lambda idx: (float(bm25_scores[idx]), -idx),
+            reverse=True,
+        )
+        selected.update(ranked_source[:per_source])
+
+    selected_indices = sorted(
+        selected,
+        key=lambda idx: (float(bm25_scores[idx]), -idx),
+        reverse=True,
+    )
+    if max_total is not None:
+        selected_indices = selected_indices[:max_total]
+    return sorted(selected_indices)
+
+
 async def _call_embedder(embedder: EmbeddingFn, inputs: list[str]) -> list[list[float]]:
     embeddings = embedder(inputs)
     if inspect.isawaitable(embeddings):
@@ -169,6 +210,8 @@ async def rank_chunks_hybrid(
     dense_query_prefix: str = "task: search result | query: ",
     dense_document_prefix: str = "title: none | text: ",
     dense_document_embed_batch_size: int | None = 32,
+    dense_bm25_prefilter_per_source: int | None = None,
+    dense_bm25_prefilter_max_total: int | None = None,
     rrf_k: int = 60,
     semaphore: "Any" = None,
     timeout_seconds: float = 60.0,
@@ -182,6 +225,9 @@ async def rank_chunks_hybrid(
     ``dense_document_embed_batch_size`` embeds the query once, then documents in
     sub-batches (default 32). Use ``None`` or ``<= 0`` to embed all documents in
     one call (legacy behavior, larger peak memory).
+    ``dense_bm25_prefilter_per_source`` and ``dense_bm25_prefilter_max_total``
+    limit dense document embedding to a BM25-selected shortlist while preserving
+    per-source representation. Use ``None`` or ``<= 0`` to disable prefiltering.
     The returned ``rrf_similarity`` is normalized to 0..1, which makes cutoffs
     easier to reason about. ``hybrid_similarity`` is kept as a compatibility alias.
     """
@@ -211,11 +257,19 @@ async def rank_chunks_hybrid(
         bm25_ranks = _rank_by_score(bm25_scores)
 
     dense_scores = [0.0 for _ in chunk_list]
-    dense_ranks = {idx: 1 for idx in range(len(chunk_list))}
+    dense_ranks = {idx: len(chunk_list) + 1 for idx in range(len(chunk_list))}
+    dense_candidate_indices = list(range(len(chunk_list)))
     if dense_weight > 0.0:
+        dense_candidate_indices = _select_dense_candidate_indices(
+            bm25_scores,
+            chunk_list,
+            per_source=dense_bm25_prefilter_per_source,
+            max_total=dense_bm25_prefilter_max_total,
+        )
+        dense_candidate_texts = [chunk_texts[idx] for idx in dense_candidate_indices]
         query_embedding, doc_embeddings = await _embed_query_and_document_chunks(
             query,
-            chunk_texts,
+            dense_candidate_texts,
             dense_query_prefix=dense_query_prefix,
             dense_document_prefix=dense_document_prefix,
             embedder=embedder,
@@ -224,11 +278,20 @@ async def rank_chunks_hybrid(
             max_timeout_retries=max_timeout_retries,
             document_embed_batch_size=dense_document_embed_batch_size,
         )
-        dense_scores = [
+        candidate_dense_scores = [
             _cosine_similarity(query_embedding, chunk_embedding)
             for chunk_embedding in doc_embeddings
         ]
-        dense_ranks = _rank_by_score(dense_scores)
+        for idx, score in zip(dense_candidate_indices, candidate_dense_scores, strict=True):
+            dense_scores[idx] = score
+        candidate_dense_ranks = _rank_by_score(candidate_dense_scores)
+        dense_ranks = {
+            idx: candidate_dense_ranks[candidate_idx]
+            for candidate_idx, idx in enumerate(dense_candidate_indices)
+        }
+        fallback_rank = len(dense_candidate_indices) + 1
+        for idx in range(len(chunk_list)):
+            dense_ranks.setdefault(idx, fallback_rank)
 
     cutoff = rrf_similarity_cutoff
     if cutoff is None:
@@ -236,6 +299,7 @@ async def rank_chunks_hybrid(
     max_rrf_score = (sparse_weight + dense_weight) / (rrf_k + 1)
 
     ranked: list[dict[str, Any]] = []
+    dense_candidate_set = set(dense_candidate_indices)
     for idx, chunk in enumerate(chunk_list):
         bm25_rank = bm25_ranks[idx]
         dense_rank = dense_ranks[idx]
@@ -255,6 +319,7 @@ async def rank_chunks_hybrid(
                 "bm25_rank": bm25_rank,
                 "dense_score": float(dense_scores[idx]),
                 "dense_rank": dense_rank,
+                "dense_candidate": idx in dense_candidate_set,
                 "rrf_score": float(rrf_score),
                 "rrf_similarity": float(rrf_similarity),
                 "hybrid_similarity": float(rrf_similarity),

--- a/services/research_config_service.py
+++ b/services/research_config_service.py
@@ -30,6 +30,8 @@ DEFAULT_RESEARCH_CONFIG: dict[str, Any] = {
     "chunk_rank_oversample": 3,
     "chunk_dedupe_jaccard_threshold": 0.92,
     "chunk_max_per_source_url": 4,
+    "chunk_dense_bm25_prefilter_per_source": 16,
+    "chunk_dense_bm25_prefilter_max_total": 128,
     "max_concurrent_crawls": 5,
     "max_concurrent_embedding_calls": 3,
     "pipeline_timeout_seconds": 120.0,
@@ -74,6 +76,10 @@ _INT_FIELDS = {
     "crawl_max_page_tokens",
     "dense_document_embed_batch_size",
 }
+_NULLABLE_INT_FIELDS = {
+    "chunk_dense_bm25_prefilter_per_source",
+    "chunk_dense_bm25_prefilter_max_total",
+}
 _FLOAT_FIELDS = {
     "search_rrf_cutoff",
     "search_dense_weight",
@@ -93,6 +99,8 @@ def _coerce_config(raw: dict[str, Any]) -> dict[str, Any]:
         config.pop(legacy, None)
     for key in _INT_FIELDS:
         config[key] = int(config[key])
+    for key in _NULLABLE_INT_FIELDS:
+        config[key] = int(config[key]) if config.get(key) is not None else None
     for key in _FLOAT_FIELDS:
         config[key] = float(config[key])
     raw_timeout = config.get("pipeline_timeout_seconds")
@@ -193,6 +201,8 @@ def research_run_kwargs(config: dict[str, Any] | None = None) -> dict[str, Any]:
         "chunk_rank_oversample",
         "chunk_dedupe_jaccard_threshold",
         "chunk_max_per_source_url",
+        "chunk_dense_bm25_prefilter_per_source",
+        "chunk_dense_bm25_prefilter_max_total",
         "max_concurrent_crawls",
         "max_concurrent_embedding_calls",
         "pipeline_timeout_seconds",

--- a/tests/test_agentic_research_pipeline.py
+++ b/tests/test_agentic_research_pipeline.py
@@ -299,6 +299,64 @@ class AgenticResearchPipelineTests(unittest.IsolatedAsyncioTestCase):
                 crawl_fn=_fake_crawl,
             )
 
+    async def test_pipeline_traces_chunk_prefilter_dense_candidate_count(self) -> None:
+        def many_results(query: str, limit: int) -> list[SearchResult]:
+            return [
+                SearchResult(
+                    result_id=idx + 1,
+                    title=f"Python {idx}",
+                    url=f"https://example.com/python-{idx}",
+                    text="Python asyncio search guide.",
+                )
+                for idx in range(2)
+            ]
+
+        async def many_chunks_crawl(**kwargs):
+            markdown = "\n\n".join(
+                f"Python async search section {idx}." for idx in range(10)
+            )
+            return {
+                "url": kwargs["url"],
+                "markdown": markdown,
+                "markdown_raw": markdown,
+                "html": "",
+                "tokens_raw": 100,
+            }
+
+        embedded_document_inputs = 0
+
+        async def counting_embedder(inputs: list[str]) -> list[list[float]]:
+            nonlocal embedded_document_inputs
+            embedded_document_inputs += sum(
+                1 for text in inputs if text != "python async search"
+            )
+            return [[1.0, 0.0] if "python" in text.lower() else [0.0, 1.0] for text in inputs]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "trace.json"
+            await agentic_run(
+                "python async search",
+                search_top_k=2,
+                search_max_results_to_keep=2,
+                chunk_max_results_to_keep=2,
+                crawl_max_chunk_tokens=5,
+                crawl_overlap_tokens=0,
+                chunk_dense_bm25_prefilter_per_source=2,
+                chunk_dense_bm25_prefilter_max_total=4,
+                dense_query_prefix="",
+                dense_document_prefix="",
+                embedder=counting_embedder,
+                search_fn=many_results,
+                crawl_fn=many_chunks_crawl,
+                trace_path=str(trace_path),
+            )
+
+            trace = json.loads(trace_path.read_text(encoding="utf-8"))
+
+        self.assertGreater(trace["chunk_ranking"]["chunks_total"], 4)
+        self.assertEqual(trace["chunk_ranking"]["dense_candidates"], 4)
+        self.assertLess(embedded_document_inputs, trace["chunk_ranking"]["chunks_total"] + 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hybrid_embed_search_service.py
+++ b/tests/test_hybrid_embed_search_service.py
@@ -199,6 +199,72 @@ class HybridEmbedSearchServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(call_sizes, [1, 2])
         self.assertEqual([chunk["chunk_id"] for chunk in ranked], ["python", "bread"])
 
+    async def test_dense_bm25_prefilter_embeds_per_source_shortlist(self) -> None:
+        chunks = [
+            {
+                "chunk_id": f"{source}-{idx}",
+                "source_url": f"https://example.com/{source}",
+                "text": text,
+            }
+            for source in ("a", "b")
+            for idx, text in enumerate(
+                [
+                    "python async search exact match",
+                    "python async secondary match",
+                    "unrelated filler text",
+                    "another unrelated filler",
+                ]
+            )
+        ]
+        embedded_docs: list[str] = []
+
+        async def embedder(inputs: list[str]) -> list[list[float]]:
+            vectors: list[list[float]] = []
+            for text in inputs:
+                normalized = text.removeprefix("task: search result | query: ").removeprefix(
+                    "title: none | text: "
+                )
+                if normalized != "python async search":
+                    embedded_docs.append(normalized)
+                vectors.append([1.0, 0.0] if "python" in normalized else [0.0, 1.0])
+            return vectors
+
+        ranked = await rank_chunks_hybrid(
+            "python async search",
+            chunks,
+            embedder=embedder,
+            dense_bm25_prefilter_per_source=1,
+            dense_bm25_prefilter_max_total=4,
+        )
+
+        self.assertEqual(len(embedded_docs), 2)
+        self.assertEqual(
+            {chunk["source_url"] for chunk in ranked if chunk["dense_candidate"]},
+            {"https://example.com/a", "https://example.com/b"},
+        )
+
+    async def test_dense_bm25_prefilter_skips_small_pools(self) -> None:
+        chunks = [
+            {"chunk_id": "python", "source_url": "https://example.com/a", "text": "python async search"},
+            {"chunk_id": "bread", "source_url": "https://example.com/b", "text": "bread recipes"},
+        ]
+        call_sizes: list[int] = []
+
+        async def embedder(inputs: list[str]) -> list[list[float]]:
+            call_sizes.append(len(inputs))
+            return [[1.0, 0.0] if "python" in text else [0.0, 1.0] for text in inputs]
+
+        ranked = await rank_chunks_hybrid(
+            "python async search",
+            chunks,
+            embedder=embedder,
+            dense_bm25_prefilter_per_source=1,
+            dense_bm25_prefilter_max_total=10,
+        )
+
+        self.assertEqual(call_sizes, [1, 2])
+        self.assertTrue(all(chunk["dense_candidate"] for chunk in ranked))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Embedding every crawl chunk can be expensive for large chunk pools and may waste compute on repeated sources, so we want to limit dense embedding to a BM25-selected shortlist while preserving per-source representation.
- The change aims to bound dense embedding work per pipeline run while keeping hybrid ranking quality by selecting top BM25 candidates per source.
- Expose prefilter knobs via config and API so callers can tune or disable the behavior.

### Description
- Add `_select_dense_candidate_indices` and `_source_url` helpers and a `dense_candidate` flag in `rank_chunks_hybrid` to prefilter documents for dense embedding by BM25 per-source shortlist and a global `max_total` cap.
- Wire new parameters `dense_bm25_prefilter_per_source` and `dense_bm25_prefilter_max_total` through `_rank`, `agentic_run`, and the call into `rank_chunks_hybrid`, and add default config values in `configs/research_config.json` and `services/research_config_service.py`.
- Surface override fields on the FastAPI request model (`ResearchRequest`) and add pipeline observability in trace/progress payloads via `trace["chunk_ranking"]` and progress events including `dense_candidates` and `chunks_total`.
- Add unit tests covering per-source shortlist behavior, small-pool bypass, and pipeline trace observability in `tests/test_hybrid_embed_search_service.py` and `tests/test_agentic_research_pipeline.py`.

### Testing
- Ran the targeted tests with `python -m pytest tests/test_hybrid_embed_search_service.py tests/test_agentic_research_pipeline.py tests/test_fastapi_scrape_endpoint.py` and the subset passed.
- Ran the full test suite with `python -m pytest` which completed successfully with `184 passed`.
- Compiled modules with `python -m compileall services pipelines servers tests` to ensure modules are syntactically valid and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cb30c3d90832187ccd25f5ec9cd80)