### PR TITLE
fix: exclude nav/header/footer/aside chrome before markdown generation

### DIFF
--- a/src/tinysearch/services/site_crawl_service.py
+++ b/src/tinysearch/services/site_crawl_service.py
@@ -25,6 +25,20 @@ _DEFAULT_MARKDOWN_GENERATOR_OPTIONS: dict[str, Any] = {
     "body_width": 0,
 }
 
+# Semantic HTML5 chrome tags stripped before markdown generation / content
+# filtering runs. Without this, nav menus and header/footer boilerplate can
+# outscore a BM25 content filter's relevance threshold on some sites (the
+# filter operates on Crawl4AI's block segmentation, and a short nav block can
+# survive at any threshold) and leak into the fitted markdown ahead of the
+# actual article content. Removing the elements at the DOM level, before
+# markdown/filtering even runs, is the correct fix -- confirmed empirically
+# that no relevance threshold in [1.5, 4.0] filtered this content, while
+# excluding these tags removed it cleanly on every test site without
+# truncating real article content. Does not catch every kind of boilerplate
+# (e.g. an inline login-CTA banner not wrapped in one of these tags), just
+# the common semantically-tagged chrome.
+_BOILERPLATE_EXCLUDED_TAGS: list[str] = ["nav", "header", "footer", "aside"]
+
 
 @lru_cache(maxsize=1)
 def _crawl4ai_stack() -> tuple[Any, Any, Any, Any, Any, Any]:
@@ -116,11 +130,11 @@ def _crawler_config_for_fit_markdown(
     )
     mode = fit_markdown_mode.strip().lower()
     if mode in ("", "off", "none", "raw"):
-        return CrawlerRunConfig(verbose=False)
+        return CrawlerRunConfig(verbose=False, excluded_tags=_BOILERPLATE_EXCLUDED_TAGS)
     if mode == "bm25":
         q = (user_query or "").strip()
         if not q:
-            return CrawlerRunConfig(verbose=False)
+            return CrawlerRunConfig(verbose=False, excluded_tags=_BOILERPLATE_EXCLUDED_TAGS)
         content_filter = BM25ContentFilter(
             user_query=q,
             bm25_threshold=bm25_threshold,
@@ -135,6 +149,7 @@ def _crawler_config_for_fit_markdown(
         )
     return CrawlerRunConfig(
         verbose=False,
+        excluded_tags=_BOILERPLATE_EXCLUDED_TAGS,
         markdown_generator=DefaultMarkdownGenerator(
             content_filter=content_filter,
             options=dict(_DEFAULT_MARKDOWN_GENERATOR_OPTIONS),
@@ -378,6 +393,7 @@ async def fetch_html_for_query(
     )
     config = CrawlerRunConfig(
         verbose=False,
+        excluded_tags=_BOILERPLATE_EXCLUDED_TAGS,
         markdown_generator=DefaultMarkdownGenerator(
             content_filter=bm25_filter,
             options=dict(_DEFAULT_MARKDOWN_GENERATOR_OPTIONS),

--- a/tests/test_site_crawl_service.py
+++ b/tests/test_site_crawl_service.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+
+from tinysearch.services.site_crawl_service import (
+    _BOILERPLATE_EXCLUDED_TAGS,
+    _crawler_config_for_fit_markdown,
+)
+
+
+class CrawlerConfigBoilerplateExclusionTests(unittest.TestCase):
+    """nav/header/footer/aside chrome must be excluded before markdown
+    generation or content filtering runs in every fit_markdown_mode branch --
+    a BM25 relevance threshold alone does not reliably filter this content
+    out (verified empirically: identical leaked output across thresholds
+    1.5-4.0 on a real site), so it has to be stripped at the DOM level."""
+
+    def test_off_mode_excludes_boilerplate_tags(self) -> None:
+        config = _crawler_config_for_fit_markdown(
+            fit_markdown_mode="off",
+            user_query=None,
+            bm25_threshold=1.5,
+            bm25_language="english",
+            pruning_threshold=0.48,
+        )
+        self.assertEqual(config.excluded_tags, _BOILERPLATE_EXCLUDED_TAGS)
+
+    def test_bm25_mode_excludes_boilerplate_tags(self) -> None:
+        config = _crawler_config_for_fit_markdown(
+            fit_markdown_mode="bm25",
+            user_query="what is a bloom filter used for",
+            bm25_threshold=1.5,
+            bm25_language="english",
+            pruning_threshold=0.48,
+        )
+        self.assertEqual(config.excluded_tags, _BOILERPLATE_EXCLUDED_TAGS)
+
+    def test_bm25_mode_with_empty_query_falls_back_but_still_excludes_tags(self) -> None:
+        config = _crawler_config_for_fit_markdown(
+            fit_markdown_mode="bm25",
+            user_query="   ",
+            bm25_threshold=1.5,
+            bm25_language="english",
+            pruning_threshold=0.48,
+        )
+        self.assertEqual(config.excluded_tags, _BOILERPLATE_EXCLUDED_TAGS)
+
+    def test_pruning_mode_excludes_boilerplate_tags(self) -> None:
+        config = _crawler_config_for_fit_markdown(
+            fit_markdown_mode="pruning",
+            user_query=None,
+            bm25_threshold=1.5,
+            bm25_language="english",
+            pruning_threshold=0.48,
+        )
+        self.assertEqual(config.excluded_tags, _BOILERPLATE_EXCLUDED_TAGS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Sets `excluded_tags=["nav", "header", "footer", "aside"]` on the two `CrawlerRunConfig` construction sites (`_crawler_config_for_fit_markdown`, used by the research pipeline's `crawl()`; `fetch_html_for_query`, used by the `scrape_url` tool), so semantic-HTML5 page chrome is stripped at the DOM level before markdown generation or content filtering ever runs.

## Why

Found while measuring real research-pipeline output quality: a top-ranked chunk for a real query included page-chrome noise ahead of the actual content:

```
SystemDesign.tech
Home Contact Search  Login Register
Home Contact Search
Login Register
System Design 1246 views

# Bloom Filters Explained in Simple Words
**Tip:** Select any text in this article to create a note with your thoughts and insights!
By saurav9760 September 21, 2025
[... real content starts here ...]
```

Initially assumed this was a `crawl_bm25_threshold` tuning problem, but verified empirically it isn't: crawling the exact same URL directly (isolating out search-result variance) at thresholds 1.5, 2.0, 2.5, 3.0, and 4.0 produced byte-identical 6622-char output every time -- the BM25 relevance filter has zero effect on this leak regardless of threshold, likely because it operates on Crawl4AI's block-level segmentation and this nav block survives at any score.

`excluded_tags` removes the elements before any of that scoring happens, which is the correct fix layer rather than trying to tune around it.

## Verification (real sites, not synthetic)

| Site | Before | After | Result |
|---|---|---|---|
| systemdesign.tech (Bloom filter article) | 6622 chars, boilerplate-first | 1110 chars | All boilerplate gone, all real content intact |
| en.wikipedia.org (DNS article) | 31120 chars, starts with a bare TOC fragment | 26979 chars | TOC nav-noise removed, full article body preserved |
| brilliant.org (Bloom filter wiki) | Login-CTA banner present | Login-CTA banner still present | No regression, but this specific banner isn't in a `nav`/`header`/`footer`/`aside` tag -- noted as a known remaining gap, not claiming this fixes every boilerplate case |

Not claiming this is a complete fix for all page-chrome leakage -- it's a real, verified improvement for the common semantically-tagged case, with an honest limitation noted for content that isn't tagged that way.

BTW, I found your post on Reddit and I just had to try it out. I will be using in my homelab.

## Test plan

- [x] 4 new unit tests (`tests/test_site_crawl_service.py`) confirm `excluded_tags` is set in every `fit_markdown_mode` branch (off / bm25 / bm25-with-empty-query / pruning)
- [x] Full existing suite passes unchanged: `python -m unittest discover tests` -> 245 tests, 1 skipped (pre-existing, unrelated), 0 failures
- [x] Manually verified against 3 real sites (table above), not synthetic fixtures