### PR TITLE
build: harden Docker publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,12 +146,34 @@ jobs:
         run: python -m unittest tests.test_live_search
 
   docker-build:
-    name: Docker build smoke test
+    name: Docker security and smoke test
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Scan container configuration
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: config
+          scan-ref: Dockerfile
+          scanners: misconfig
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          trivyignores: .trivyignore.yaml
+
+      - name: Scan repository for secrets
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: secret
+          skip-dirs: .venv
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -168,3 +190,15 @@ jobs:
 
       - name: Smoke-test image entrypoint
         run: docker run --rm tinysearch:test tinysearch --help
+
+      - name: Scan image for vulnerabilities and secrets
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_IMAGE_CONFIG_SCANNERS: secret
+        with:
+          image-ref: tinysearch:test
+          scanners: vuln,secret
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,6 +65,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Scan container configuration
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: config
+          scan-ref: Dockerfile
+          scanners: misconfig
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          trivyignores: .trivyignore.yaml
+
+      - name: Scan repository for secrets
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: secret
+          skip-dirs: .venv
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v4.5.2
         with:
@@ -86,8 +108,11 @@ jobs:
 
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_IMAGE_CONFIG_SCANNERS: secret
         with:
           image-ref: ${{ env.IMAGE_NAME }}:scan
+          scanners: vuln,secret
           format: table
           severity: CRITICAL,HIGH
           exit-code: "1"
@@ -100,6 +125,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
+          provenance: mode=max
           build-args: |
             TINYSEARCH_VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.tags.outputs.value }}

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -1,0 +1,27 @@
+name: Rescan published Docker image
+
+on:
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan Docker Hub image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Scan latest published image
+        uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_IMAGE_CONFIG_SCANNERS: secret
+        with:
+          image-ref: marcellm01/tinysearch:latest
+          scanners: vuln,secret
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,10 @@
+misconfigurations:
+  - id: AVD-DS-0002
+    paths:
+      - Dockerfile
+    expired_at: 2027-07-31
+    statement: >-
+      The entrypoint starts as root only to repair bind-mounted directory
+      ownership, then immediately execs the requested command through gosu as
+      the unprivileged tinysearch user. Revisit this exception if volume
+      initialization moves outside the runtime container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN mkdir -p /ms-playwright \
     && pip install --upgrade pip \
     && pip install ".[server]" \
     && python -m playwright install --with-deps chromium \
+    && pip check \
+    && pip uninstall --yes pip setuptools \
     && chmod -R a+rX /ms-playwright \
     && useradd --create-home --shell /usr/sbin/nologin tinysearch \
     && mkdir -p /data/models /app/trace_logs \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinysuite-search"
-version = "0.4.1"
+version = "0.4.2"
 description = "Local web retrieval with ranked, source-grounded evidence."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.TinySuiteHQ/tinysearch",
   "description": "Self-hosted web research for MCP agents.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "websiteUrl": "https://github.com/TinySuiteHQ/TinySearch",
   "repository": {
     "url": "https://github.com/TinySuiteHQ/TinySearch",
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "docker.io/marcellm01/tinysearch:v0.4.1",
+      "identifier": "docker.io/marcellm01/tinysearch:v0.4.2",
       "transport": {
         "type": "stdio"
       },
@@ -52,7 +52,7 @@
     {
       "registryType": "pypi",
       "identifier": "tinysuite-search",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- gate pull requests and Docker releases on Trivy configuration, secret, and image scans
- publish SBOM and max-level provenance attestations alongside signed multi-architecture images
- rescan the published `latest` image weekly
- validate installed Python dependencies and remove packaging tools from the runtime image
- document the temporary root-entrypoint exception used before dropping privileges with `gosu`

## Why

The release workflow previously scanned image vulnerabilities only at publish time. This adds earlier pull-request feedback, secret and configuration coverage, recurring checks for newly disclosed vulnerabilities, and verifiable supply-chain metadata.

## Validation

- built the image locally
- confirmed the entrypoint runs as UID/GID 1000
- confirmed runtime imports succeed without `pip` or `setuptools`
- ran Trivy configuration, repository secret, image vulnerability, and image metadata secret scans with zero gated findings
- parsed all workflow and Trivy YAML files and ran `git diff --check`