### PR TITLE
Allow agents to formulate retrieval queries

### DIFF
--- a/agentic_coding_templates/global-rules-recommended.md
+++ b/agentic_coding_templates/global-rules-recommended.md
@@ -12,12 +12,12 @@ This environment uses the **tinysearch** MCP server. It exposes **three** tools.
 
 **`research(query)`**
 
-- **Input:** a single string field **`query`** only. Pass the user’s question **as-is**: do not rewrite, spell-correct, add dates, expand abbreviations, translate, or “improve” the wording before calling.
+- **Input:** a single string field **`query`** only. Formulate the query for effective retrieval. You may rewrite, clarify terminology, correct spelling, expand abbreviations, add relevant temporal context, translate, or narrow the request when useful. Preserve important names, constraints, qualifiers, negations, and the user’s underlying intent.
 - **Output:** a **search-grounded XML prompt** directly (not a finished article). It aggregates ranked web results, crawled page text, and chunk context. **Your job** is to answer the user from that prompt and **cite source URLs** contained in its `<result>` elements.
 
 **`scrape_url(url, query)`**
 
-- **Input:** **`url`** (required) and **`query`** (required, non-empty). Pass **`query` as-is** with the same no-rewrite rule as `research`.
+- **Input:** **`url`** (required) and **`query`** (required, non-empty). Use a focused retrieval query describing the information to find within the page; it does not need to reproduce the user’s wording.
 - **When to use:** the user supplied a specific URL, or a prior search already identified the exact page to inspect. Do **not** use this for open-ended discovery, use **`research(query)`** instead.
 - **Output:** a **URL-grounded XML prompt** directly (not a finished article). It contains the page content most relevant to `query`; retrieval diagnostics are attributes on `<url_grounded_answer>`. **Your job** is to answer from that prompt and **cite the URL in its `<page>` element**.
 - **Errors:** failures surface as `ValueError` with stable code prefixes: `invalid_url`, `blocked_url`, `unsupported_document`, `empty_content`, `fetch_failed`, `fetch_timeout`.
@@ -54,6 +54,8 @@ Use it when you need **up-to-date external facts** and primary sources, and you 
 - “What are the alternatives to Z?”
 - “What changed between versions?”
 
+Formulate the query around the information needed rather than mechanically copying the user’s wording. Preserve factual constraints and intent when rewriting.
+
 Prefer **URLs and short quotes** from the prompt text. External claims should be grounded in what `research` surfaced.
 
 #### When to use `scrape_url(url, query)`
@@ -62,7 +64,7 @@ Use it when the **target page is already known**:
 - A prior `research` result (or codebase link) already identified the exact page.
 - You need focused extraction from one doc, article, or PDF/DOCX URL, not a web-wide search.
 
-Pass the user’s question in **`query`** unchanged. Cite the URL inside the returned prompt’s **`<page>`** element (it may differ from the input after redirects).
+Use **`query`** to describe the specific information you need from the page. Refine or narrow it as needed for retrieval while preserving the relevant constraints. Cite the URL inside the returned prompt’s **`<page>`** element (it may differ from the input after redirects).
 
 #### Source hygiene
 - Prefer **official docs** over blogs when the prompt includes them.
@@ -74,13 +76,13 @@ Pass the user’s question in **`query`** unchanged. Cite the URL inside the ret
 ### Strategy with three tools
 
 1. **Time check:** for time-sensitive or relative-date questions, call **`get_current_datetime()`** first unless you already know the current UTC date and time.
-2. **Discovery first:** if you do not yet know which page to read, call **`research(query)`** once with a clear question aligned to the user’s goal.
+2. **Discovery first:** if you do not yet know which page to read, call **`research(query)`** once with a clear retrieval query aligned to the user’s goal.
 3. **Known URL:** if the user gave a URL (or one is already identified), call **`scrape_url(url, query)`** instead of re-searching for the same page.
 4. **Answer from the XML prompt**: synthesize the user’s reply from the grounded evidence and pull URLs from its `<result>` or `<page>` elements for citations.
 5. If the prompt is thin on one angle, **refine `query`** and call the same tool again with a narrower follow-up, or switch tools only when the gap is “find a page” (`research`) vs “read this page” (`scrape_url`).
 
 #### If the user gave an exact URL
-Call **`scrape_url(url, query)`** with the pasted URL and the user’s question as `query`. Do not route URL-only fetches through **`research(query)`** unless you also need broader discovery beyond that page.
+Call **`scrape_url(url, query)`** with the pasted URL and a focused query describing what you need to extract. Do not route URL-only fetches through **`research(query)`** unless you also need broader discovery beyond that page.
 
 #### If results look partial or empty
 - For **`research`**, retry at most once with a **tightened or alternate `query`**.

--- a/src/tinysearch/servers/mcp_server.py
+++ b/src/tinysearch/servers/mcp_server.py
@@ -166,10 +166,10 @@ Before calling research for time-sensitive questions, or if you need to add
 year/month/day context to a query, call get_current_datetime() first to orient
 on the current date and time (UTC).
 
-Pass the user's question as-is in query. Do not rewrite, correct spelling,
-expand abbreviations, add dates, add missing context, simplify, translate, or
-otherwise improve the user's wording before calling either tool, unless temporal
-augmentation is genuinely needed after checking get_current_datetime().
+Formulate queries for effective retrieval. You may rewrite, clarify terminology,
+correct spelling, expand abbreviations, add relevant temporal context, translate,
+or narrow the request when useful. Preserve important names, constraints,
+qualifiers, negations, and the user's underlying intent.
 
 Use research first when you need to discover relevant URLs. It searches the web
 through the configured backend (SearXNG by default, with a DuckDuckGo fallback),
@@ -236,8 +236,9 @@ async def get_current_datetime_tool() -> dict[str, str]:
     description=(
         "Discover relevant URLs for the user's question, crawl ranked pages, "
         "and return a search-grounded XML answer prompt directly. "
-        "Use this first when you need to find sources. "
-        "Pass the user's question as-is. For time-sensitive or relative-date "
+        "Use this first when you need to find sources. Formulate the query "
+        "for effective retrieval while preserving the user's important "
+        "constraints and intent. For time-sensitive or relative-date "
         "questions, call get_current_datetime() first unless you already "
         "know the current date and time."
     ),
@@ -247,8 +248,9 @@ async def research(
         str,
         Field(
             description=(
-                "The user's question, passed exactly as written. Use this for "
-                "open-ended discovery when you need to find relevant URLs."
+                "A search/research query describing the information to find. "
+                "Rewrite or refine it as needed for effective retrieval while "
+                "preserving important names, constraints, qualifiers, and intent."
             )
         ),
     ],
@@ -281,7 +283,8 @@ async def research(
         "Inspect a specific URL and return a grounded XML answer prompt containing "
         "the page content most relevant to the requested query. Use this after "
         "the user provides a URL or research already identified the page to "
-        "inspect. Pass the user's query without rewriting it."
+        "inspect. Formulate a focused retrieval query for the information needed "
+        "from that page."
     ),
 )
 async def scrape_url_tool(
@@ -298,8 +301,8 @@ async def scrape_url_tool(
         str,
         Field(
             description=(
-                "The user's question, passed exactly as written. The page is "
-                "ranked against this query."
+                "What information to find within this page. Formulate a focused "
+                "retrieval query appropriate to the content needed from the URL."
             )
         ),
     ],


### PR DESCRIPTION
## What changed

TinySearch no longer instructs MCP clients to pass the user's wording verbatim into `research` and `scrape_url`.

- `research` now allows the calling model to rewrite, clarify, translate, narrow, spell-correct, or add relevant temporal context to improve retrieval.
- Query guidance explicitly preserves important names, constraints, qualifiers, negations, and user intent.
- `scrape_url` now asks for a focused page-retrieval query rather than a copy of the user's original question.
- The recommended agent rules have been updated to match the MCP tool descriptions.

## Why

The calling model has the conversational context needed to formulate a better search query. Requiring verbatim user wording can degrade web search, embedding, BM25, and page-chunk ranking when the original request is conversational, ambiguous, abbreviated, or otherwise poorly shaped for retrieval.

This keeps query planning with the agent while leaving TinySearch responsible for search, crawling, filtering, and retrieval.

## Scope

No search pipeline or ranking behavior is changed. This is limited to MCP instructions/tool schemas and the recommended agent guidance.