### PR TITLE
scrape_urls: share one browser across concurrent items

### DIFF
--- a/src/tinysearch/core.py
+++ b/src/tinysearch/core.py
@@ -10,6 +10,7 @@ pipeline) lives here exactly once.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import Mapping, Sequence
 from functools import partial
 from typing import Any
@@ -21,6 +22,7 @@ from tinysearch.results import public_chunk, result_envelope
 from tinysearch.services.current_datetime_service import current_datetime_payload
 from tinysearch.services.embedding_service import normalize_embedding_backend
 from tinysearch.services.scrape_service import DEFAULT_SCRAPE_MAX_TOKENS
+from tinysearch.services.site_crawl_service import create_browser_crawler, is_document_url
 from tinysearch.services.tinysearch_config_service import normalize_query
 from tinysearch.services.web_search_service import (
     filter_blocked_search_results,
@@ -123,6 +125,7 @@ async def _scrape_url_with_config(
     *,
     max_tokens: int,
     config: dict[str, Any],
+    crawler: Any | None,
 ) -> dict[str, Any]:
     scrape_result = await run_scrape_pipeline(
         url,
@@ -130,6 +133,7 @@ async def _scrape_url_with_config(
         max_tokens=max_tokens,
         include_metadata=True,
         config=config,
+        crawler=crawler,
     )
     source = {
         "id": "1",
@@ -184,18 +188,23 @@ async def scrape_urls(
     if any((query or "").strip() not in {"", "*"} for _, query in normalized):
         await _ensure_local_bundle_for_config(resolved)
     await _ensure_browser_bundle()
-    settled = await asyncio.gather(
-        *(
-            _scrape_url_with_config(
-                url,
-                query,
-                max_tokens=max_tokens,
-                config=resolved,
-            )
-            for url, query in normalized
-        ),
-        return_exceptions=True,
-    )
+
+    needs_browser = any(not is_document_url(url) for url, _ in normalized)
+    crawler_ctx = create_browser_crawler() if needs_browser else contextlib.nullcontext(None)
+    async with crawler_ctx as shared_crawler:
+        settled = await asyncio.gather(
+            *(
+                _scrape_url_with_config(
+                    url,
+                    query,
+                    max_tokens=max_tokens,
+                    config=resolved,
+                    crawler=shared_crawler,
+                )
+                for url, query in normalized
+            ),
+            return_exceptions=True,
+        )
     results: list[dict[str, Any]] = []
     for (url, query), outcome in zip(normalized, settled, strict=True):
         if isinstance(outcome, Exception):

--- a/src/tinysearch/pipelines/scrape.py
+++ b/src/tinysearch/pipelines/scrape.py
@@ -48,11 +48,16 @@ async def run_scrape_pipeline(
     embedder: EmbeddingFn | None = None,
     crawl_fn: HtmlCrawlFn | None = None,
     document_fn: DocumentExtractFn | None = None,
+    crawler: Any | None = None,
 ) -> ScrapeResult:
     """Extract a URL in page order, or rank chunks only for a supplied query.
 
     Omitted, blank, and ``'*'`` queries select raw page-order extraction; any
     other non-empty query enables the existing focused chunk-ranking path.
+
+    Pass `crawler` (an already-started AsyncWebCrawler, see
+    site_crawl_service.create_browser_crawler()) to reuse one browser across
+    several pipeline calls instead of launching a fresh one per call.
     """
     cleaned_query = (query or "").strip()
     raw_page_order = cleaned_query in {"", "*"}
@@ -93,6 +98,7 @@ async def run_scrape_pipeline(
             bm25_language=resolved["crawl_bm25_language"],
             timeout_seconds=fetch_timeout_seconds,
             crawl_fn=crawl_fn,
+            crawler=crawler,
         )
         final_url = str(page.get("final_url") or safe_url)
         html = str(page.get("html") or "")

--- a/src/tinysearch/pipelines/scrape.py
+++ b/src/tinysearch/pipelines/scrape.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from functools import partial
 from typing import Any
 
 from tinysearch.config import normalize_config
@@ -83,7 +84,15 @@ async def run_scrape_pipeline(
             raise UnsupportedDocumentError(
                 "legacy .doc files are not supported; use PDF or DOCX"
             )
-        document_fn = document_fn or extract_document_text
+        if document_fn is None:
+            # Bound the blocking download's own socket timeout by the pipeline
+            # budget: asyncio.timeout() below can only cancel the *awaiting*
+            # task, not the underlying to_thread() download, so an unbounded
+            # per-request timeout would keep that thread (and its socket) alive
+            # well past the point callers were told the fetch had timed out.
+            document_fn = partial(
+                extract_document_text, timeout_seconds=min(fetch_timeout_seconds, 30.0)
+            )
         markdown, _document_type = await extract_document_with_timeout(
             url=safe_url,
             timeout_seconds=fetch_timeout_seconds,

--- a/src/tinysearch/services/scrape_service.py
+++ b/src/tinysearch/services/scrape_service.py
@@ -204,15 +204,19 @@ async def fetch_html_with_timeout(
     bm25_language: str,
     timeout_seconds: float,
     crawl_fn: HtmlCrawlFn,
+    crawler: Any | None = None,
 ) -> dict[str, Any]:
     try:
         async with asyncio.timeout(timeout_seconds):
-            return await crawl_fn(
-                url=url,
-                user_query=query,
-                bm25_threshold=bm25_threshold,
-                bm25_language=bm25_language,
-            )
+            kwargs: dict[str, Any] = {
+                "url": url,
+                "user_query": query,
+                "bm25_threshold": bm25_threshold,
+                "bm25_language": bm25_language,
+            }
+            if crawler is not None:
+                kwargs["crawler"] = crawler
+            return await crawl_fn(**kwargs)
     except (asyncio.TimeoutError, TimeoutError) as exc:
         raise FetchTimeoutError(f"fetch timed out after {timeout_seconds}s") from exc
     except (InvalidUrlError, BlockedUrlError):

--- a/src/tinysearch/services/site_crawl_service.py
+++ b/src/tinysearch/services/site_crawl_service.py
@@ -373,12 +373,16 @@ async def fetch_html_for_query(
     *,
     bm25_threshold: float = 1.5,
     bm25_language: str = "english",
+    crawler: Any | None = None,
 ) -> dict[str, Any]:
     """Fetch a URL, applying a BM25 content filter only for a supplied query.
 
     Returns ``final_url``, ``html``, ``markdown_raw``, ``markdown_fit`` and the
     crawler's ``metadata`` dict. The ``final_url`` reflects the URL after any
     redirects Crawl4AI followed.
+
+    Pass `crawler` (an already-started AsyncWebCrawler, see create_browser_crawler())
+    to reuse one browser across many calls instead of launching a fresh one here.
     """
     _ensure_utf8_stdio()
 
@@ -402,8 +406,11 @@ async def fetch_html_for_query(
         )
     config = CrawlerRunConfig(**config_kwargs)
 
-    async with AsyncWebCrawler(config=_lightweight_browser_config(BrowserConfig)) as crawler:
+    if crawler is not None:
         result = await crawler.arun(url=url, config=config)
+    else:
+        async with AsyncWebCrawler(config=_lightweight_browser_config(BrowserConfig)) as owned_crawler:
+            result = await owned_crawler.arun(url=url, config=config)
 
     final_url = (
         getattr(result, "redirected_url", None)

--- a/src/tinysearch/services/site_crawl_service.py
+++ b/src/tinysearch/services/site_crawl_service.py
@@ -197,7 +197,7 @@ def is_document_url(url: str) -> bool:
     return url_path_suffix(url) in {"pdf", "docx", "doc"}
 
 
-def _download_url_bytes(url: str) -> bytes:
+def _download_url_bytes(url: str, *, timeout_seconds: float = 30.0) -> bytes:
     req = Request(
         url,
         headers={
@@ -205,7 +205,7 @@ def _download_url_bytes(url: str) -> bytes:
             "Accept": "*/*",
         },
     )
-    with urlopen(req, timeout=30) as resp:
+    with urlopen(req, timeout=timeout_seconds) as resp:
         return resp.read()
 
 
@@ -241,12 +241,12 @@ def _extract_docx_text(data: bytes) -> str:
         return "\n\n".join(parts).strip()
 
 
-def extract_document_text(url: str) -> tuple[str, str]:
+def extract_document_text(url: str, *, timeout_seconds: float = 30.0) -> tuple[str, str]:
     suffix = url_path_suffix(url)
     if suffix == "doc":
         raise ValueError("legacy .doc files are not supported; use PDF or DOCX")
 
-    data = _download_url_bytes(url)
+    data = _download_url_bytes(url, timeout_seconds=timeout_seconds)
     if suffix == "pdf":
         return _extract_pdf_text(data), "pdf"
     if suffix == "docx":

--- a/src/tinysearch/services/web_search_service.py
+++ b/src/tinysearch/services/web_search_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import re
 import socket
 import sys
 import urllib.error
@@ -13,13 +12,6 @@ from functools import lru_cache
 from typing import Any
 from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
-
-
-@lru_cache(maxsize=1)
-def _async_web_crawler_cls() -> Any:
-    from crawl4ai import AsyncWebCrawler
-
-    return AsyncWebCrawler
 
 
 @lru_cache(maxsize=1)
@@ -122,28 +114,6 @@ def filter_blocked_search_results(
         for result in search_results
         if not is_blocked_domain(result.url, blocked_domains)
     ]
-
-
-def _extract_links_from_html(html: str) -> list[str]:
-    # Very small/fast extractor; good enough for basic crawling.
-    return list(dict.fromkeys(re.findall(r'href="([^"]+)"', html, flags=re.IGNORECASE)))
-
-
-async def crawl(url: str) -> dict:
-    """
-    Crawl a page with crawl4ai and return basic extracted content.
-
-    Returns a dict with: url, markdown, html, links.
-    """
-    _ensure_utf8_stdio()
-    AsyncWebCrawler = _async_web_crawler_cls()
-    async with AsyncWebCrawler() as crawler:
-        result = await crawler.arun(url=url)
-
-    html = getattr(result, "html", "") or ""
-    markdown = getattr(result, "markdown", "") or ""
-    links = _extract_links_from_html(html) if html else []
-    return {"url": url, "markdown": markdown, "html": html, "links": links}
 
 
 def _ddgs_search(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import unittest
 from types import SimpleNamespace
@@ -92,6 +93,9 @@ class CorePublicApiTests(unittest.IsolatedAsyncioTestCase):
             new=AsyncMock(return_value=scrape_result),
         ), patch("tinysearch.core._ensure_local_bundle_for_config", new=AsyncMock()), patch(
             "tinysearch.core._ensure_browser_bundle", new=AsyncMock()
+        ), patch(
+            "tinysearch.core.create_browser_crawler",
+            return_value=contextlib.nullcontext(None),
         ):
             result = await tinysearch.scrape_urls([{"url": "https://example.com/x", "query": "q"}])
 
@@ -112,7 +116,10 @@ class CorePublicApiTests(unittest.IsolatedAsyncioTestCase):
             side_effect=[successful, ValueError("bad URL")],
         ), patch("tinysearch.core._ensure_browser_bundle", new=AsyncMock()), patch(
             "tinysearch.core._ensure_local_bundle_for_config", new=AsyncMock()
-        ) as embeddings:
+        ) as embeddings, patch(
+            "tinysearch.core.create_browser_crawler",
+            return_value=contextlib.nullcontext(None),
+        ):
             result = await scrape_urls(
                 [{"url": "https://one.example"}, {"url": "https://two.example", "query": "*"}]
             )


### PR DESCRIPTION
## Summary
- `scrape_urls` fans out over `asyncio.gather` for up to 5 URLs, but each concurrent item previously launched its own `AsyncWebCrawler` (a full Chromium + Playwright driver process). Now it shares a single browser across the batch, mirroring the pattern `research()` already uses via `create_browser_crawler()`.
- Cuts peak Chromium process/memory usage under concurrent `scrape_urls` calls. Skips launching a browser entirely when every item in the batch is a document URL (PDF/DOCX), which never touches Playwright.
- Threaded an optional `crawler` param through `fetch_html_for_query` → `fetch_html_with_timeout` → `run_scrape_pipeline` → `core._scrape_url_with_config`, all defaulting to `None` (owns its own browser), so single-item/library callers are unaffected.
- **Bounded the document-download timeout**: `extract_document_with_timeout` wraps a blocking `urlopen()` call in `asyncio.to_thread()` inside `asyncio.timeout()`. Cancelling the awaiting task can't stop the underlying thread, so a slow PDF/DOCX host kept a socket open against a hardcoded 30s timeout regardless of the caller's actual budget. `extract_document_text`/`_download_url_bytes` now accept a `timeout_seconds` bound derived from the pipeline's own timeout, so the thread doesn't outlive the point callers were already told the fetch had failed.
- **Removed dead code**: `web_search_service.crawl()` and its two helpers launched a per-call, unshared `AsyncWebCrawler` but were never wired into any real call path — superseded by `site_crawl_service`'s crawl functions.

## Related to #46
Investigating that report, I confirmed the "Task was destroyed but it is pending!" / `TargetClosedError` warning is **not** caused by TinySearch's per-item browser lifecycle — it reproduces identically with a single URL and a single browser, and in `research()`'s already-shared-browser path. It traces to `playwright`'s own `Connection.stop_async()` (`playwright/_impl/_connection.py`) not awaiting/joining the background `_init_task` it spawns in `Connection.run()` before the transport closes — an upstream Playwright driver quirk, not a bug in this repo's browser handling. This PR is a resource-usage/cleanup improvement on its own merits; it doesn't change that warning's presence. Left a note on the issue with these findings.

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 248 passed, 1 skipped
- [x] Manually ran `scrape_urls` against live URLs (single item and multi-item, document + non-document) to confirm results are unaffected