### PR TITLE
feat: add optional external browser via Chrome DevTools Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,36 @@ Brave is only consulted when the primary call errors or returns no results.
 Full key reference, SearXNG JSON-output setup, and Compose details live in the
 [configuration reference](https://tinysuite.dev/docs/tinysearch/configuration/).
 
+## External browser over CDP
+
+TinySearch uses its bundled Playwright Chromium by default. To use a browser
+that you operate separately, set its Chrome DevTools Protocol endpoint in the
+config file:
+
+```json
+{
+  "browser_cdp_url": "http://browser:9222"
+}
+```
+
+Server processes also accept `TINYSEARCH_BROWSER_CDP_URL`. When either setting
+is present, TinySearch connects through Crawl4AI instead of installing or
+launching the bundled Chromium. The external browser owns its executable,
+profile, proxy, and fingerprint configuration; TinySearch does not select or
+install a particular browser backend.
+
+Treat a CDP endpoint as privileged remote control of the browser. Keep it on a
+private network or loopback interface, require authentication when it crosses
+a host boundary, and do not expose port 9222 directly to the public internet.
+When TinySearch itself runs in Docker, `localhost` refers to the TinySearch
+container, so use an endpoint reachable from that container.
+
+The CDP endpoint is operator-managed and cannot be changed through the HTTP
+`PUT /config` endpoint, even when configuration writes are enabled. Set it in
+the startup environment or the file selected by `TINYSEARCH_CONFIG_PATH`, then
+restart TinySearch. HTTP clients can continue updating other settings by
+omitting `browser_cdp_url` from their partial update.
+
 ## Why TinySearch
 
 - **Built around token efficiency.** Page selection and passage selection

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
     environment:
       TINYSEARCH_MODELS_DIR: /data/models
       TINYSEARCH_CONFIG_PATH: /config/tinysearch_config.json
+      TINYSEARCH_BROWSER_CDP_URL: ${TINYSEARCH_BROWSER_CDP_URL:-}
       MCP_TRANSPORT: streamable-http
       MCP_HOST: 0.0.0.0
       MCP_PORT: 8000
@@ -47,6 +48,7 @@ services:
     environment:
       TINYSEARCH_MODELS_DIR: /data/models
       TINYSEARCH_CONFIG_PATH: /config/tinysearch_config.json
+      TINYSEARCH_BROWSER_CDP_URL: ${TINYSEARCH_BROWSER_CDP_URL:-}
       SEARXNG_URL: http://searxng:8080/search
     depends_on:
       - searxng

--- a/configs/tinysearch_config.json
+++ b/configs/tinysearch_config.json
@@ -60,6 +60,8 @@
   "crawl_overlap_tokens": 40,
   "_comment_crawl_max_page_tokens": "Maximum tokens retained from one crawled page before chunking. Zero disables the per-page limit.",
   "crawl_max_page_tokens": 0,
+  "_comment_browser_cdp_url": "Optional external Chrome DevTools Protocol endpoint. Leave empty to use TinySearch's bundled Chromium. Keep remote CDP endpoints private and authenticated.",
+  "browser_cdp_url": "",
 
   "_comment_embedding_backend": "Embedding implementation. Use 'onnx' for private local CPU embeddings or 'openai_compatible' for an OpenAI-compatible embedding API.",
   "embedding_backend": "onnx",

--- a/src/tinysearch/config.py
+++ b/src/tinysearch/config.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from tinysearch.services.embedding_service import (
     DEFAULT_EMBEDDING_BACKEND,
@@ -66,6 +67,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "search_backend_fallback": True,
     "ddgs_timeout_seconds": 20.0,
     "ddgs_backend": "auto",
+    "browser_cdp_url": "",
     "trace_path": "",
 }
 
@@ -128,10 +130,24 @@ def normalize_config(raw: Mapping[str, Any] | None = None) -> dict[str, Any]:
         "crawl_fit_markdown_mode",
         "crawl_bm25_language",
         "ddgs_backend",
+        "browser_cdp_url",
         "trace_path",
     ):
         if config.get(key) is not None:
             config[key] = str(config[key])
+
+    browser_cdp_url = config["browser_cdp_url"].strip()
+    if browser_cdp_url:
+        parsed_cdp_url = urlsplit(browser_cdp_url)
+        if parsed_cdp_url.scheme.lower() not in {"http", "https", "ws", "wss"}:
+            raise ValueError(
+                "tinysearch config browser_cdp_url must use http, https, ws, or wss"
+            )
+        if not parsed_cdp_url.hostname:
+            raise ValueError(
+                "tinysearch config browser_cdp_url must include a hostname"
+            )
+    config["browser_cdp_url"] = browser_cdp_url
 
     embedding_backend = normalize_embedding_backend(
         str(config.get("embedding_backend") or DEFAULT_EMBEDDING_BACKEND)

--- a/src/tinysearch/core.py
+++ b/src/tinysearch/core.py
@@ -53,7 +53,9 @@ async def _ensure_local_bundle_for_config(config: dict[str, Any]) -> None:
     await asyncio.to_thread(ensure_onnx_bundle_sync, str(config["embedding_model"]))
 
 
-async def _ensure_browser_bundle() -> None:
+async def _ensure_browser_bundle(config: Mapping[str, Any]) -> None:
+    if str(config.get("browser_cdp_url") or "").strip():
+        return
     from tinysearch.services.browser_bundle_service import ensure_chromium_sync
 
     await asyncio.to_thread(ensure_chromium_sync)
@@ -110,7 +112,7 @@ async def research(query: str, *, config: ConfigInput | None = None) -> dict[str
     query = normalize_query(query)
     resolved_config = _resolve_config(config)
     await _ensure_local_bundle_for_config(resolved_config)
-    await _ensure_browser_bundle()
+    await _ensure_browser_bundle(resolved_config)
     result = await run_research_pipeline(
         query,
         config=resolved_config,
@@ -187,10 +189,14 @@ async def scrape_urls(
     resolved = _resolve_config(config)
     if any((query or "").strip() not in {"", "*"} for _, query in normalized):
         await _ensure_local_bundle_for_config(resolved)
-    await _ensure_browser_bundle()
+    await _ensure_browser_bundle(resolved)
 
     needs_browser = any(not is_document_url(url) for url, _ in normalized)
-    crawler_ctx = create_browser_crawler() if needs_browser else contextlib.nullcontext(None)
+    crawler_ctx = (
+        create_browser_crawler(resolved)
+        if needs_browser
+        else contextlib.nullcontext(None)
+    )
     async with crawler_ctx as shared_crawler:
         settled = await asyncio.gather(
             *(

--- a/src/tinysearch/doctor.py
+++ b/src/tinysearch/doctor.py
@@ -10,6 +10,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from tinysearch.services.embedding_service import (
     normalize_embedding_backend,
@@ -38,6 +39,39 @@ def _check_chromium() -> tuple[bool, str]:
     if executable.exists():
         return True, str(executable)
     return False, f"Chromium executable not found at {executable} (run `tinysearch setup`)"
+
+
+def _display_cdp_endpoint(cdp_url: str) -> str:
+    parsed = urlsplit(cdp_url)
+    host = parsed.hostname or "unknown-host"
+    try:
+        port = f":{parsed.port}" if parsed.port is not None else ""
+    except ValueError:
+        port = ""
+    return f"{parsed.scheme}://{host}{port}"
+
+
+def _check_cdp_browser(cdp_url: str) -> tuple[bool, str]:
+    endpoint = _display_cdp_endpoint(cdp_url)
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return False, "playwright is not installed"
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.connect_over_cdp(cdp_url, timeout=5_000)
+            try:
+                connected = browser.is_connected()
+            finally:
+                browser.close()
+    except Exception as exc:
+        return False, (
+            f"could not connect to external CDP browser at {endpoint} "
+            f"({type(exc).__name__})"
+        )
+    if connected:
+        return True, f"connected to external CDP browser at {endpoint}"
+    return False, f"external CDP browser disconnected at {endpoint}"
 
 
 def _check_model(config: dict[str, Any]) -> tuple[bool, str]:
@@ -70,8 +104,14 @@ def run() -> int:
         f"({'found' if config_path.exists() else 'not found, using built-in defaults'})"
     )
 
+    browser_cdp_url = str(config.get("browser_cdp_url") or "").strip()
+    browser_check = (
+        ("external browser", *_check_cdp_browser(browser_cdp_url))
+        if browser_cdp_url
+        else ("chromium", *_check_chromium())
+    )
     checks = [
-        ("chromium", *_check_chromium()),
+        browser_check,
         ("model", *_check_model(config)),
         ("config dir writable", *_check_writable(config_path.parent)),
     ]

--- a/src/tinysearch/pipelines/research.py
+++ b/src/tinysearch/pipelines/research.py
@@ -420,7 +420,9 @@ async def run_research_pipeline(
                     }
 
             crawler_ctx = (
-                create_browser_crawler() if using_default_crawl_fn else contextlib.nullcontext(None)
+                create_browser_crawler(resolved)
+                if using_default_crawl_fn
+                else contextlib.nullcontext(None)
             )
             async with crawler_ctx as shared_crawler:
                 crawled_results = await asyncio.gather(

--- a/src/tinysearch/servers/fastapi_server.py
+++ b/src/tinysearch/servers/fastapi_server.py
@@ -13,6 +13,9 @@ from tinysearch.services.tinysearch_config_service import (
 )
 
 
+_OPERATOR_MANAGED_CONFIG_FIELDS = frozenset({"browser_cdp_url"})
+
+
 def _tinysearch_version() -> str:
     return os.environ.get("TINYSEARCH_VERSION", "dev").strip() or "dev"
 
@@ -65,7 +68,12 @@ async def current_datetime_endpoint() -> dict[str, str]:
 async def get_config_endpoint() -> dict[str, Any]:
     config = load_tinysearch_config()
     return {
-        key: ("***" if any(marker in key.lower() for marker in ("secret", "token", "api_key")) else value)
+        key: (
+            "***"
+            if (key == "browser_cdp_url" and value)
+            or any(marker in key.lower() for marker in ("secret", "token", "api_key"))
+            else value
+        )
         for key, value in config.items()
     }
 
@@ -93,6 +101,23 @@ async def put_config_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
                     "Set TINYSEARCH_CONFIG_PATH to an explicit writable override "
                     "file before enabling config updates."
                 ),
+            },
+        )
+    operator_managed_fields = sorted(
+        _OPERATOR_MANAGED_CONFIG_FIELDS.intersection(payload)
+    )
+    if operator_managed_fields:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "operator_managed_config",
+                "message": (
+                    "browser_cdp_url cannot be changed over HTTP. Configure it "
+                    "at startup with TINYSEARCH_BROWSER_CDP_URL or in the file "
+                    "selected by TINYSEARCH_CONFIG_PATH, then restart TinySearch. "
+                    "Omit browser_cdp_url when updating other settings."
+                ),
+                "fields": operator_managed_fields,
             },
         )
     try:

--- a/src/tinysearch/services/site_crawl_service.py
+++ b/src/tinysearch/services/site_crawl_service.py
@@ -2,6 +2,7 @@ import asyncio
 import re
 import sys
 import tempfile
+from collections.abc import Mapping
 from functools import lru_cache
 from typing import Any
 from urllib.parse import urlparse
@@ -157,18 +158,38 @@ def _crawler_config_for_fit_markdown(
     )
 
 
-def _lightweight_browser_config(BrowserConfig: Any) -> Any:
-    """BrowserConfig tuned to cut Chromium's memory/process footprint.
+def _lightweight_browser_config(
+    BrowserConfig: Any,
+    config: Mapping[str, Any] | None = None,
+) -> Any:
+    """Build BrowserConfig for bundled Chromium or an external CDP browser.
 
-    Deliberately does NOT touch `java_script_enabled` or disable JS in any way,
-    since that would break markdown extraction quality on JS-rendered pages.
-    Only non-content-affecting knobs:
+    Bundled Chromium keeps JavaScript enabled and uses only
+    non-content-affecting footprint controls:
     - light_mode: drops crashpad/extensions/sync/translate companion processes
     - memory_saving_mode: caps each renderer's V8 heap (~512MB) and discards
       caches aggressively
     - avoid_ads: blocks known ad/tracker network origins
     - extra_args: blocks images/fonts at the browser level; we only need text.
     """
+    cdp_url = str((config or {}).get("browser_cdp_url") or "").strip()
+    if cdp_url:
+        browser_config = BrowserConfig(
+            verbose=False,
+            browser_mode="custom",
+            cdp_url=cdp_url,
+            cdp_cleanup_on_close=True,
+            cdp_close_delay=0,
+            avoid_ads=True,
+        )
+        # Crawl4AI 0.9.2 parses ``user_agent`` during construction and crashes
+        # when it is passed as None, even though BrowserConfig documents None as
+        # supported. Clear both derived fields after construction so setup_context
+        # leaves the external browser's coherent identity untouched.
+        browser_config.user_agent = None
+        browser_config.browser_hint = ""
+        return browser_config
+
     return BrowserConfig(
         verbose=False,
         light_mode=True,
@@ -178,7 +199,7 @@ def _lightweight_browser_config(BrowserConfig: Any) -> Any:
     )
 
 
-def create_browser_crawler() -> Any:
+def create_browser_crawler(config: Mapping[str, Any] | None = None) -> Any:
     """Construct an AsyncWebCrawler meant to be reused across many crawl() calls.
 
     Launching a fresh Chromium browser per crawled URL is the dominant memory
@@ -186,7 +207,7 @@ def create_browser_crawler() -> Any:
     batch cuts peak memory substantially while preserving full JS rendering.
     """
     AsyncWebCrawler, BrowserConfig, _, _, _, _ = _crawl4ai_stack()
-    return AsyncWebCrawler(config=_lightweight_browser_config(BrowserConfig))
+    return AsyncWebCrawler(config=_lightweight_browser_config(BrowserConfig, config))
 
 
 def url_path_suffix(url: str) -> str:

--- a/src/tinysearch/services/tinysearch_config_service.py
+++ b/src/tinysearch/services/tinysearch_config_service.py
@@ -49,6 +49,9 @@ def load_tinysearch_config(path: str | Path | None = None) -> dict[str, Any]:
     embedding_model = os.environ.get("TINYSEARCH_EMBEDDING_MODEL", "").strip()
     if embedding_model:
         overrides["embedding_model"] = embedding_model
+    browser_cdp_url = os.environ.get("TINYSEARCH_BROWSER_CDP_URL", "").strip()
+    if browser_cdp_url:
+        overrides["browser_cdp_url"] = browser_cdp_url
     return (
         config.with_overrides(overrides).to_dict()
         if overrides

--- a/src/tinysearch/setup.py
+++ b/src/tinysearch/setup.py
@@ -1,4 +1,4 @@
-"""Install Chromium and download the configured ONNX embedding model.
+"""Install required local browser and embedding bundles.
 
 All output goes to stderr, matching `doctor`, this can run adjacent to an
 MCP stdio server, so stdout must stay clean.
@@ -18,9 +18,12 @@ def _log(message: str) -> None:
 
 
 def run(with_system_deps: bool = False) -> int:
-    install_chromium(with_system_deps)
-
     config = load_tinysearch_config()
+    if str(config.get("browser_cdp_url") or "").strip():
+        _log("browser_cdp_url is configured; skipping bundled Chromium install")
+    else:
+        install_chromium(with_system_deps)
+
     if normalize_embedding_backend(str(config["embedding_backend"])) == "onnx":
         from tinysearch.services.onnx_bundle_service import ensure_onnx_bundle_sync
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, patch
 
 import tinysearch
 from tinysearch.config import DEFAULT_CONFIG, TinySearchConfig
-from tinysearch.core import _ensure_local_bundle_for_config, scrape_urls
+from tinysearch.core import (
+    _ensure_browser_bundle,
+    _ensure_local_bundle_for_config,
+    scrape_urls,
+)
 from tinysearch.pipelines.research import ResearchResult
 from tinysearch.results import result_envelope
 
@@ -146,6 +150,22 @@ class CorePublicApiTests(unittest.IsolatedAsyncioTestCase):
                 {"embedding_backend": "onnx", "embedding_model": "fast"}
             )
         ensure.assert_called_once_with("fast")
+
+    async def test_external_cdp_skips_bundled_chromium_install(self) -> None:
+        with patch(
+            "tinysearch.services.browser_bundle_service.ensure_chromium_sync"
+        ) as ensure:
+            await _ensure_browser_bundle({"browser_cdp_url": "http://browser:9222"})
+
+        ensure.assert_not_called()
+
+    async def test_default_browser_ensures_bundled_chromium(self) -> None:
+        with patch(
+            "tinysearch.services.browser_bundle_service.ensure_chromium_sync"
+        ) as ensure:
+            await _ensure_browser_bundle({"browser_cdp_url": ""})
+
+        ensure.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -43,6 +43,32 @@ class DoctorOutputTests(unittest.TestCase):
 
         ensure.assert_not_called()
 
+    def test_run_checks_external_cdp_instead_of_bundled_chromium(self) -> None:
+        config = {
+            "browser_cdp_url": "https://token@example.test/cdp?secret=value",
+            "embedding_backend": "openai_compatible",
+            "embedding_model": "x",
+        }
+        with patch.object(
+            doctor, "load_tinysearch_config", return_value=config
+        ), patch.object(
+            doctor, "_check_cdp_browser", return_value=(True, "ok")
+        ) as check_cdp, patch.object(doctor, "_check_chromium") as check_chromium, patch.object(
+            doctor, "_check_writable", return_value=(True, "ok")
+        ):
+            exit_code = doctor.run()
+
+        self.assertEqual(exit_code, 0)
+        check_cdp.assert_called_once_with(config["browser_cdp_url"])
+        check_chromium.assert_not_called()
+
+    def test_cdp_display_endpoint_omits_credentials_path_and_query(self) -> None:
+        endpoint = doctor._display_cdp_endpoint(
+            "wss://user:secret@example.test:9443/devtools/browser/id?token=value"
+        )
+
+        self.assertEqual(endpoint, "wss://example.test:9443")
+
 
 class DoctorCheckModelTests(unittest.TestCase):
     def test_reports_missing_bundle(self) -> None:

--- a/tests/test_fastapi_current_datetime.py
+++ b/tests/test_fastapi_current_datetime.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
-from tinysearch.servers.fastapi_server import current_datetime_endpoint
+from fastapi import HTTPException
+
+from tinysearch.servers.fastapi_server import (
+    current_datetime_endpoint,
+    get_config_endpoint,
+    put_config_endpoint,
+)
 
 
 class FastApiCurrentDatetimeTests(unittest.IsolatedAsyncioTestCase):
@@ -19,6 +25,74 @@ class FastApiCurrentDatetimeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(payload["date_utc"], "2026-06-28")
         self.assertEqual(payload["time_utc"], "08:10:00")
+
+    async def test_config_endpoint_redacts_external_cdp_url(self) -> None:
+        with patch(
+            "tinysearch.servers.fastapi_server.load_tinysearch_config",
+            return_value={
+                "browser_cdp_url": "wss://example.test/cdp?token=secret",
+                "search_backend": "ddgs",
+            },
+        ):
+            payload = await get_config_endpoint()
+
+        self.assertEqual(payload["browser_cdp_url"], "***")
+        self.assertEqual(payload["search_backend"], "ddgs")
+
+    async def test_config_endpoint_keeps_empty_cdp_default_visible(self) -> None:
+        with patch(
+            "tinysearch.servers.fastapi_server.load_tinysearch_config",
+            return_value={"browser_cdp_url": ""},
+        ):
+            payload = await get_config_endpoint()
+
+        self.assertEqual(payload["browser_cdp_url"], "")
+
+    async def test_config_update_rejects_operator_managed_cdp_url(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "TINYSEARCH_CONFIG_WRITABLE": "1",
+                "TINYSEARCH_CONFIG_PATH": "config.json",
+            },
+            clear=True,
+        ), patch(
+            "tinysearch.servers.fastapi_server.save_tinysearch_config"
+        ) as save_config:
+            with self.assertRaises(HTTPException) as raised:
+                await put_config_endpoint(
+                    {"browser_cdp_url": "http://browser:9222"}
+                )
+
+        self.assertEqual(raised.exception.status_code, 403)
+        self.assertEqual(
+            raised.exception.detail["code"], "operator_managed_config"
+        )
+        self.assertEqual(
+            raised.exception.detail["fields"], ["browser_cdp_url"]
+        )
+        self.assertIn(
+            "TINYSEARCH_BROWSER_CDP_URL",
+            raised.exception.detail["message"],
+        )
+        save_config.assert_not_called()
+
+    async def test_config_update_allows_other_fields(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "TINYSEARCH_CONFIG_WRITABLE": "1",
+                "TINYSEARCH_CONFIG_PATH": "config.json",
+            },
+            clear=True,
+        ), patch(
+            "tinysearch.servers.fastapi_server.save_tinysearch_config",
+            return_value={"search_backend": "searxng"},
+        ) as save_config:
+            payload = await put_config_endpoint({"search_backend": "searxng"})
+
+        self.assertEqual(payload, {"search_backend": "searxng"})
+        save_config.assert_called_once_with({"search_backend": "searxng"})
 
 
 if __name__ == "__main__":

--- a/tests/test_public_config_and_results.py
+++ b/tests/test_public_config_and_results.py
@@ -18,6 +18,7 @@ class PublicConfigTests(unittest.TestCase):
         config = TinySearchConfig()
         self.assertEqual(config["search_backend"], "ddgs")
         self.assertEqual(config.search_backend, "ddgs")
+        self.assertEqual(config.browser_cdp_url, "")
         json.dumps(config.to_dict())
 
     def test_explicit_file_then_call_overrides(self) -> None:
@@ -91,6 +92,31 @@ class PublicConfigTests(unittest.TestCase):
             config = load_tinysearch_config()
         self.assertEqual(config["embedding_backend"], "onnx")
         self.assertEqual(config["embedding_model"], "quality")
+
+    def test_browser_cdp_url_is_normalized_and_validated(self) -> None:
+        config = TinySearchConfig(browser_cdp_url="  http://browser:9222  ")
+        self.assertEqual(config.browser_cdp_url, "http://browser:9222")
+
+        for invalid_url in ("browser:9222", "ftp://browser:9222", "ws:///devtools"):
+            with self.subTest(invalid_url=invalid_url), self.assertRaisesRegex(
+                ValueError, "browser_cdp_url"
+            ):
+                TinySearchConfig(browser_cdp_url=invalid_url)
+
+    def test_server_loader_applies_browser_cdp_environment_override(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "TINYSEARCH_CONFIG_PATH": "/does/not/exist.json",
+                "TINYSEARCH_BROWSER_CDP_URL": "ws://browser:9222/devtools/browser/id",
+            },
+            clear=True,
+        ):
+            config = load_tinysearch_config()
+        self.assertEqual(
+            config["browser_cdp_url"],
+            "ws://browser:9222/devtools/browser/id",
+        )
 
 
 class PublicResultTests(unittest.TestCase):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -40,6 +40,19 @@ class SetupRunTests(unittest.TestCase):
 
         install.assert_called_once_with(True)
 
+    def test_external_cdp_skips_chromium_install(self) -> None:
+        config = {
+            "browser_cdp_url": "http://browser:9222",
+            "embedding_backend": "openai_compatible",
+            "embedding_model": "fast",
+        }
+        with patch.object(setup_module, "install_chromium") as install, patch.object(
+            setup_module, "load_tinysearch_config", return_value=config
+        ):
+            setup_module.run()
+
+        install.assert_not_called()
+
 
 class InstallChromiumTests(unittest.TestCase):
     def test_non_linux_ignores_with_system_deps(self) -> None:

--- a/tests/test_site_crawl_service.py
+++ b/tests/test_site_crawl_service.py
@@ -5,7 +5,35 @@ import unittest
 from tinysearch.services.site_crawl_service import (
     _BOILERPLATE_EXCLUDED_TAGS,
     _crawler_config_for_fit_markdown,
+    _lightweight_browser_config,
 )
+
+
+class _RecordingBrowserConfig:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+
+class BrowserBackendConfigTests(unittest.TestCase):
+    def test_default_uses_bundled_lightweight_browser(self) -> None:
+        config = _lightweight_browser_config(_RecordingBrowserConfig)
+
+        self.assertTrue(config.kwargs["light_mode"])
+        self.assertTrue(config.kwargs["memory_saving_mode"])
+        self.assertNotIn("cdp_url", config.kwargs)
+
+    def test_external_cdp_preserves_backend_identity(self) -> None:
+        config = _lightweight_browser_config(
+            _RecordingBrowserConfig,
+            {"browser_cdp_url": "http://browser:9222"},
+        )
+
+        self.assertEqual(config.kwargs["browser_mode"], "custom")
+        self.assertEqual(config.kwargs["cdp_url"], "http://browser:9222")
+        self.assertTrue(config.kwargs["cdp_cleanup_on_close"])
+        self.assertEqual(config.kwargs["cdp_close_delay"], 0)
+        self.assertIsNone(config.user_agent)
+        self.assertEqual(config.browser_hint, "")
 
 
 class CrawlerConfigBoilerplateExclusionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add an opt-in `browser_cdp_url` config setting (also settable via `TINYSEARCH_BROWSER_CDP_URL`) that connects Crawl4AI to an externally-managed Chrome browser over CDP instead of TinySearch's bundled Chromium.
- When set, TinySearch skips installing/launching the bundled Chromium, `doctor` verifies the external browser is reachable, and the CDP endpoint is treated as operator-managed: redacted in `GET /config` and rejected (403) from `PUT /config` so it can only be changed via env var or config file + restart.

## Test plan
- [x] `uv run python -m unittest discover -s tests -p "test_*.py"` — 261 passed, 1 skipped
- [ ] Manual: point `browser_cdp_url` at a real Chrome instance with `--remote-debugging-port` and confirm `research`/`scrape` work end-to-end