### PR TITLE
Add semantic deduplication for ranked crawl chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,43 @@ the startup environment or the file selected by `TINYSEARCH_CONFIG_PATH`, then
 restart TinySearch. HTTP clients can continue updating other settings by
 omitting `browser_cdp_url` from their partial update.
 
+## Semantic deduplication of evidence
+
+Research ranks an oversampled pool of page chunks, then trims it down to the
+final evidence set. Two duplicate filters run during that trim:
+
+1. **Lexical (always on).** Token-set Jaccard drops near-identical copied text.
+   Controlled by `chunk_dedupe_jaccard_threshold` (default `0.92`; lower is more
+   aggressive, `1.0` disables it).
+2. **Semantic (optional).** Cosine similarity over the chunk embeddings already
+   computed during ranking drops syndicated, paraphrased, or reworded passages
+   that carry the same information with little literal token overlap, exactly
+   the duplicates Jaccard misses.
+
+```json
+{
+  "chunk_semantic_dedupe_enabled": true,
+  "chunk_semantic_dedupe_threshold": 0.92
+}
+```
+
+- `chunk_semantic_dedupe_enabled`: turn the semantic stage on or off. Enabled
+  by default.
+- `chunk_semantic_dedupe_threshold`: cosine similarity (`0` to `1`) above which a
+  chunk is treated as a semantic duplicate of an already-selected chunk. Lower
+  values deduplicate more aggressively; keep it conservative (~`0.92`) so
+  genuinely distinct-but-related evidence is not discarded. `1.0` effectively
+  disables the stage.
+
+**Design tradeoffs.** The semantic stage reuses embeddings from the ranking
+step, so it adds no extra embedding calls and runs on the already-bounded
+oversampled pool. It runs *after* the cheap lexical filter and compares each
+candidate against the running selected output in ranked order, so the
+highest-ranked member of a duplicate group is always the one kept, and per-source
+quotas and fill behavior are preserved. Setting the threshold too low can merge
+distinct facts that happen to be phrased similarly, which is why it defaults to a
+conservative value and can be disabled entirely.
+
 ## Why TinySearch
 
 - **No vendor in the loop.** No TinySearch account, no required API key, no

--- a/configs/tinysearch_config.json
+++ b/configs/tinysearch_config.json
@@ -37,6 +37,10 @@
   "chunk_rank_oversample": 3,
   "_comment_chunk_dedupe_jaccard_threshold": "Research only. Near-duplicate threshold from 0 to 1. Lower values deduplicate more aggressively.",
   "chunk_dedupe_jaccard_threshold": 0.92,
+  "_comment_chunk_semantic_dedupe_enabled": "Research only. When true, adds embedding-based semantic deduplication after lexical Jaccard so syndicated or paraphrased chunks with low token overlap are dropped. Reuses ranking embeddings (no extra embedding calls).",
+  "chunk_semantic_dedupe_enabled": true,
+  "_comment_chunk_semantic_dedupe_threshold": "Research only. Cosine similarity from 0 to 1 above which a chunk is treated as a semantic duplicate of an already-selected chunk. Lower values deduplicate more aggressively; keep conservative (~0.92) to avoid dropping distinct evidence.",
+  "chunk_semantic_dedupe_threshold": 0.92,
   "_comment_chunk_max_per_source_url": "Research only. Maximum selected chunks from one URL, preventing a single page from crowding out other sources.",
   "chunk_max_per_source_url": 4,
 

--- a/src/tinysearch/config.py
+++ b/src/tinysearch/config.py
@@ -36,6 +36,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "chunk_max_results_to_keep": 2,
     "chunk_rank_oversample": 3,
     "chunk_dedupe_jaccard_threshold": 0.92,
+    "chunk_semantic_dedupe_enabled": True,
+    "chunk_semantic_dedupe_threshold": 0.92,
     "chunk_max_per_source_url": 4,
     "max_concurrent_crawls": 5,
     "max_concurrent_embedding_calls": 3,
@@ -96,11 +98,19 @@ _FLOAT_FIELDS = {
     "chunk_rrf_cutoff",
     "chunk_dense_weight",
     "chunk_dedupe_jaccard_threshold",
+    "chunk_semantic_dedupe_threshold",
     "crawl_bm25_threshold",
     "crawl_pruning_threshold",
     "embedding_timeout_seconds",
     "ddgs_timeout_seconds",
 }
+
+
+def _coerce_bool(value: Any) -> bool:
+    """Coerce config values (including JSON strings like "false"/"0") to bool."""
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def normalize_config(raw: Mapping[str, Any] | None = None) -> dict[str, Any]:
@@ -205,6 +215,9 @@ def normalize_config(raw: Mapping[str, Any] | None = None) -> dict[str, Any]:
     config.pop("search_country", None)
     config["search_backend_fallback"] = bool(
         config.get("search_backend_fallback", True)
+    )
+    config["chunk_semantic_dedupe_enabled"] = _coerce_bool(
+        config.get("chunk_semantic_dedupe_enabled", True)
     )
     return config
 

--- a/src/tinysearch/pipelines/research.py
+++ b/src/tinysearch/pipelines/research.py
@@ -165,6 +165,8 @@ async def run_research_pipeline(
     crawl_pruning_threshold = resolved["crawl_pruning_threshold"]
     chunk_rank_oversample = resolved["chunk_rank_oversample"]
     chunk_dedupe_jaccard_threshold = resolved["chunk_dedupe_jaccard_threshold"]
+    chunk_semantic_dedupe_enabled = resolved["chunk_semantic_dedupe_enabled"]
+    chunk_semantic_dedupe_threshold = resolved["chunk_semantic_dedupe_threshold"]
     chunk_max_per_source_url = resolved["chunk_max_per_source_url"]
     encoding_name = resolved["encoding_name"]
     embedding_backend = resolved["embedding_backend"]
@@ -217,6 +219,8 @@ async def run_research_pipeline(
             "crawl_pruning_threshold": crawl_pruning_threshold,
             "chunk_rank_oversample": chunk_rank_oversample,
             "chunk_dedupe_jaccard_threshold": chunk_dedupe_jaccard_threshold,
+            "chunk_semantic_dedupe_enabled": chunk_semantic_dedupe_enabled,
+            "chunk_semantic_dedupe_threshold": chunk_semantic_dedupe_threshold,
             "chunk_max_per_source_url": chunk_max_per_source_url,
             "encoding_name": encoding_name or "embedding",
             "tokenizer_name": None,
@@ -457,12 +461,21 @@ async def run_research_pipeline(
                 dense_document_prefix=dense_document_prefix,
                 dense_document_embed_batch_size=dense_document_embed_batch_size,
             )
+            semantic_dedupe_rejections: list[dict[str, Any]] = []
             ranked_chunk_pool = select_chunks_with_quota_and_fill(
                 ranked_wide,
                 final_limit=chunk_max_results_to_keep,
                 max_per_source_url=chunk_max_per_source_url,
                 dedupe_jaccard_threshold=chunk_dedupe_jaccard_threshold,
+                semantic_dedupe_enabled=chunk_semantic_dedupe_enabled,
+                semantic_dedupe_threshold=chunk_semantic_dedupe_threshold,
+                rejections=semantic_dedupe_rejections,
             )
+            trace["semantic_dedupe_rejections"] = semantic_dedupe_rejections
+            # Drop the reused dense embeddings now that selection is done so they do not
+            # bloat trace files or downstream chunk payloads.
+            for chunk in ranked_chunk_pool:
+                chunk.pop("dense_embedding", None)
             chunks_by_url: dict[str, list[dict[str, Any]]] = {}
             for chunk in ranked_chunk_pool:
                 chunks_by_url.setdefault(str(chunk.get("source_url") or ""), []).append(chunk)

--- a/src/tinysearch/services/chunk_pool_selection_service.py
+++ b/src/tinysearch/services/chunk_pool_selection_service.py
@@ -1,10 +1,19 @@
 """
 Post-processing for globally ranked retrieval chunks: Jaccard near-duplicate suppression,
-per-source quotas, then optional filler slots (dedupe only) to reach a target top-K.
+optional embedding-based semantic deduplication, per-source quotas, then optional filler
+slots (dedupe only) to reach a target top-K.
+
+Lexical Jaccard runs first as a cheap prefilter. When semantic deduplication is enabled it
+runs as a second stage against the running selected output, rejecting candidates whose dense
+embedding cosine similarity to an already-accepted chunk exceeds a configurable threshold.
+This catches syndicated / paraphrased / reworded content that shares little literal token
+overlap. Embeddings are reused from the ranking stage (chunk key ``dense_embedding``) so no
+extra embedding calls are made here.
 """
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import Any
 
@@ -41,6 +50,51 @@ def _max_jaccard_to_accepted(candidate: frozenset[str], accepted_sets: list[froz
         for s in accepted_sets
         if s
     )
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity of two dense vectors; returns 0.0 for empty or zero-norm inputs."""
+    if not a or not b:
+        return 0.0
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+    if norm_a <= 0.0 or norm_b <= 0.0:
+        return 0.0
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
+
+
+def _chunk_embedding(chunk: dict[str, Any], embedding_key: str) -> list[float] | None:
+    raw = chunk.get(embedding_key)
+    if not raw:
+        return None
+    try:
+        return [float(v) for v in raw]
+    except (TypeError, ValueError):
+        return None
+
+
+def _max_cosine_to_accepted(
+    candidate: list[float] | None,
+    accepted_embeddings: list[list[float] | None],
+) -> tuple[float, int]:
+    """Return the (best cosine, index) of ``candidate`` against accepted embeddings."""
+    if candidate is None:
+        return 0.0, -1
+    best = 0.0
+    best_idx = -1
+    for idx, emb in enumerate(accepted_embeddings):
+        if emb is None:
+            continue
+        sim = cosine_similarity(candidate, emb)
+        if sim > best:
+            best = sim
+            best_idx = idx
+    return best, best_idx
 
 
 def dedupe_chunks_by_token_jaccard(
@@ -81,14 +135,29 @@ def select_chunks_with_quota_and_fill(
     final_limit: int,
     max_per_source_url: int,
     dedupe_jaccard_threshold: float,
+    semantic_dedupe_enabled: bool = False,
+    semantic_dedupe_threshold: float = 0.92,
     source_key: str = "source_url",
     text_key: str = "text",
+    embedding_key: str = "dense_embedding",
+    rejections: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """
     Dedupe globally, enforce at most ``max_per_source_url`` chunks per ``source_url`` in a first pass,
     then fill toward ``final_limit`` from the remaining ranked candidates while skipping the
-    per-source cap but still rejecting near-duplicates (Jaccard) against the running output.
+    per-source cap but still rejecting near-duplicates against the running output.
     If ``max_per_source_url <= 0``, only dedupe and truncate to ``final_limit``.
+
+    Lexical Jaccard dedup always runs first as a cheap prefilter. When ``semantic_dedupe_enabled``
+    is true, a second stage rejects candidates whose ``embedding_key`` cosine similarity to an
+    already-accepted chunk is ``>= semantic_dedupe_threshold``. Because candidates are visited in
+    ranked order, the highest-ranked member of a duplicate group is the one retained. Semantic
+    dedup reuses embeddings attached during ranking and never triggers new embedding calls; a
+    candidate with no usable embedding is passed through the semantic stage unchanged.
+
+    When ``rejections`` is provided, one diagnostic record is appended per dropped candidate:
+    ``{"chunk_id", "reason", "similarity", "matched_chunk_id"}`` where ``reason`` is
+    ``"semantic_duplicate"`` (lexical drops are handled by the standard Jaccard filter).
     """
     limit = max(0, final_limit)
     if limit == 0:
@@ -101,16 +170,14 @@ def select_chunks_with_quota_and_fill(
     )
 
     dedupe_relaxed = dedupe_jaccard_threshold >= 1.0
+    semantic_active = semantic_dedupe_enabled and semantic_dedupe_threshold < 1.0
 
-    if max_per_source_url <= 0:
-        return ranked[:limit]
-
-    url_counts: dict[str, int] = {}
-    chosen_ids: set[Any] = set()
-    out: list[dict[str, Any]] = []
     accepted_sets: list[frozenset[str]] = []
+    accepted_embeddings: list[list[float] | None] = []
+    accepted_ids: list[Any] = []
+    out: list[dict[str, Any]] = []
 
-    def accepts_dedupe(chunk: dict[str, Any]) -> bool:
+    def accepts_lexical(chunk: dict[str, Any]) -> bool:
         if dedupe_relaxed:
             return True
         text = str(chunk.get(text_key) or "").strip()
@@ -121,13 +188,49 @@ def select_chunks_with_quota_and_fill(
             )
         return _max_jaccard_to_accepted(tokens, accepted_sets) < dedupe_jaccard_threshold
 
+    semantic_rejected: set[Any] = set()
+
+    def accepts_semantic(chunk: dict[str, Any]) -> bool:
+        if not semantic_active:
+            return True
+        candidate = _chunk_embedding(chunk, embedding_key)
+        if candidate is None:
+            return True
+        best, best_idx = _max_cosine_to_accepted(candidate, accepted_embeddings)
+        if best >= semantic_dedupe_threshold:
+            # A candidate can be revisited in the fill pass; record its rejection once.
+            if rejections is not None and _chunk_identity(chunk) not in semantic_rejected:
+                matched_id = accepted_ids[best_idx] if best_idx >= 0 else None
+                rejections.append(
+                    {
+                        "chunk_id": chunk.get("chunk_id"),
+                        "reason": "semantic_duplicate",
+                        "similarity": float(best),
+                        "matched_chunk_id": matched_id,
+                    }
+                )
+            semantic_rejected.add(_chunk_identity(chunk))
+            return False
+        return True
+
     def append_chunk(chunk: dict[str, Any]) -> None:
-        cid = _chunk_identity(chunk)
-        chosen_ids.add(cid)
         out.append(chunk)
         text = str(chunk.get(text_key) or "").strip()
-        tokens = _token_set(text)
-        accepted_sets.append(tokens)
+        accepted_sets.append(_token_set(text))
+        accepted_embeddings.append(_chunk_embedding(chunk, embedding_key))
+        accepted_ids.append(chunk.get("chunk_id"))
+
+    if max_per_source_url <= 0:
+        for chunk in ranked:
+            if len(out) >= limit:
+                break
+            if not accepts_semantic(chunk):
+                continue
+            append_chunk(chunk)
+        return out[:limit]
+
+    url_counts: dict[str, int] = {}
+    chosen_ids: set[Any] = set()
 
     for chunk in ranked:
         if len(out) >= limit:
@@ -138,9 +241,12 @@ def select_chunks_with_quota_and_fill(
         url = str(chunk.get(source_key) or "")
         if url_counts.get(url, 0) >= max_per_source_url:
             continue
-        if not accepts_dedupe(chunk):
+        if not accepts_lexical(chunk):
+            continue
+        if not accepts_semantic(chunk):
             continue
         url_counts[url] = url_counts.get(url, 0) + 1
+        chosen_ids.add(cid)
         append_chunk(chunk)
 
     if len(out) < limit:
@@ -150,8 +256,11 @@ def select_chunks_with_quota_and_fill(
             cid = _chunk_identity(chunk)
             if cid in chosen_ids:
                 continue
-            if not accepts_dedupe(chunk):
+            if not accepts_lexical(chunk):
                 continue
+            if not accepts_semantic(chunk):
+                continue
+            chosen_ids.add(cid)
             append_chunk(chunk)
 
     return out[:limit]

--- a/src/tinysearch/services/hybrid_embed_search_service.py
+++ b/src/tinysearch/services/hybrid_embed_search_service.py
@@ -212,6 +212,7 @@ async def rank_chunks_hybrid(
 
     dense_scores = [0.0 for _ in chunk_list]
     dense_ranks = {idx: 1 for idx in range(len(chunk_list))}
+    doc_embeddings: list[list[float]] = []
     if dense_weight > 0.0:
         query_embedding, doc_embeddings = await _embed_query_and_document_chunks(
             query,
@@ -248,18 +249,21 @@ async def rank_chunks_hybrid(
         if cutoff is not None and rrf_similarity < cutoff:
             continue
 
-        ranked.append(
-            {
-                **chunk,
-                "bm25_score": float(bm25_scores[idx]),
-                "bm25_rank": bm25_rank,
-                "dense_score": float(dense_scores[idx]),
-                "dense_rank": dense_rank,
-                "rrf_score": float(rrf_score),
-                "rrf_similarity": float(rrf_similarity),
-                "hybrid_similarity": float(rrf_similarity),
-            }
-        )
+        ranked_chunk = {
+            **chunk,
+            "bm25_score": float(bm25_scores[idx]),
+            "bm25_rank": bm25_rank,
+            "dense_score": float(dense_scores[idx]),
+            "dense_rank": dense_rank,
+            "rrf_score": float(rrf_score),
+            "rrf_similarity": float(rrf_similarity),
+            "hybrid_similarity": float(rrf_similarity),
+        }
+        # Preserve the dense document embedding so downstream selection (e.g. semantic
+        # deduplication) can reuse it via cosine similarity without re-embedding.
+        if idx < len(doc_embeddings):
+            ranked_chunk["dense_embedding"] = list(doc_embeddings[idx])
+        ranked.append(ranked_chunk)
 
     ranked.sort(
         key=lambda item: (

--- a/tests/test_chunk_pool_selection_service.py
+++ b/tests/test_chunk_pool_selection_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 from tinysearch.services.chunk_pool_selection_service import (
+    cosine_similarity,
     dedupe_chunks_by_token_jaccard,
     jaccard_similarity_tokens,
     select_chunks_with_quota_and_fill,
@@ -49,6 +50,150 @@ class ChunkPoolSelectionServiceTests(unittest.TestCase):
         )
         urls = [c["source_url"] for c in picked]
         self.assertGreaterEqual(urls.count("https://two.example/"), 1)
+
+
+class SemanticDedupeTests(unittest.TestCase):
+    # Two chunks that paraphrase the same fact with almost no shared tokens, plus a
+    # clearly distinct one. Embeddings encode the "meaning" so the two paraphrases are
+    # near-collinear while the distinct chunk points elsewhere.
+    PARAPHRASE_A = {
+        "chunk_id": "a",
+        "source_url": "https://a.example/",
+        "text": "The rollout begins next Monday for every enrolled account.",
+        "dense_embedding": [1.0, 0.0, 0.0],
+    }
+    PARAPHRASE_B = {
+        "chunk_id": "b",
+        "source_url": "https://b.example/",
+        "text": "Starting the first weekday of the week, all signed-up users get access.",
+        # cosine(A, B) == 0.96 (0.96^2 + 0.28^2 == 1)
+        "dense_embedding": [0.96, 0.28, 0.0],
+    }
+    DISTINCT = {
+        "chunk_id": "c",
+        "source_url": "https://c.example/",
+        "text": "Pricing tiers remain unchanged through the end of the fiscal year.",
+        "dense_embedding": [0.0, 0.0, 1.0],
+    }
+
+    def test_cosine_similarity_basics(self) -> None:
+        self.assertAlmostEqual(cosine_similarity([1.0, 0.0], [1.0, 0.0]), 1.0)
+        self.assertAlmostEqual(cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0)
+        self.assertEqual(cosine_similarity([], [1.0]), 0.0)
+        self.assertEqual(cosine_similarity([0.0, 0.0], [1.0, 1.0]), 0.0)
+
+    def test_semantic_dedup_drops_low_jaccard_paraphrase(self) -> None:
+        rejections: list[dict] = []
+        picked = select_chunks_with_quota_and_fill(
+            [self.PARAPHRASE_A, self.PARAPHRASE_B, self.DISTINCT],
+            final_limit=5,
+            max_per_source_url=0,
+            dedupe_jaccard_threshold=0.92,
+            semantic_dedupe_enabled=True,
+            semantic_dedupe_threshold=0.9,
+            rejections=rejections,
+        )
+        ids = [c["chunk_id"] for c in picked]
+        # Highest-ranked paraphrase kept, its near-duplicate dropped, distinct chunk kept.
+        self.assertEqual(ids, ["a", "c"])
+        self.assertEqual(len(rejections), 1)
+        self.assertEqual(rejections[0]["reason"], "semantic_duplicate")
+        self.assertEqual(rejections[0]["chunk_id"], "b")
+        self.assertEqual(rejections[0]["matched_chunk_id"], "a")
+        self.assertGreaterEqual(rejections[0]["similarity"], 0.9)
+
+    def test_semantic_dedup_disabled_keeps_paraphrase(self) -> None:
+        # Jaccard cannot see the paraphrase (low token overlap), so with semantic
+        # dedup off both paraphrases survive.
+        picked = select_chunks_with_quota_and_fill(
+            [self.PARAPHRASE_A, self.PARAPHRASE_B, self.DISTINCT],
+            final_limit=5,
+            max_per_source_url=0,
+            dedupe_jaccard_threshold=0.92,
+            semantic_dedupe_enabled=False,
+        )
+        self.assertEqual([c["chunk_id"] for c in picked], ["a", "b", "c"])
+
+    def test_semantic_threshold_controls_aggressiveness(self) -> None:
+        # A high threshold treats the paraphrases as distinct.
+        picked = select_chunks_with_quota_and_fill(
+            [self.PARAPHRASE_A, self.PARAPHRASE_B, self.DISTINCT],
+            final_limit=5,
+            max_per_source_url=0,
+            dedupe_jaccard_threshold=0.92,
+            semantic_dedupe_enabled=True,
+            semantic_dedupe_threshold=0.99,
+        )
+        self.assertEqual([c["chunk_id"] for c in picked], ["a", "b", "c"])
+
+    def test_semantic_dedup_keeps_related_but_distinct_chunks(self) -> None:
+        picked = select_chunks_with_quota_and_fill(
+            [self.PARAPHRASE_A, self.DISTINCT],
+            final_limit=5,
+            max_per_source_url=0,
+            dedupe_jaccard_threshold=0.92,
+            semantic_dedupe_enabled=True,
+            semantic_dedupe_threshold=0.9,
+        )
+        self.assertEqual([c["chunk_id"] for c in picked], ["a", "c"])
+
+    def test_semantic_dedup_passes_through_chunks_without_embeddings(self) -> None:
+        # Missing embeddings must never crash or over-drop; such chunks skip the
+        # semantic stage and are governed by lexical dedup only.
+        chunks = [
+            {"chunk_id": "a", "source_url": "https://a/", "text": "alpha beta gamma"},
+            {"chunk_id": "b", "source_url": "https://b/", "text": "delta epsilon zeta"},
+        ]
+        picked = select_chunks_with_quota_and_fill(
+            chunks,
+            final_limit=5,
+            max_per_source_url=0,
+            dedupe_jaccard_threshold=0.92,
+            semantic_dedupe_enabled=True,
+            semantic_dedupe_threshold=0.9,
+        )
+        self.assertEqual([c["chunk_id"] for c in picked], ["a", "b"])
+
+    def test_semantic_dedup_cooperates_with_quota_and_fill(self) -> None:
+        # u2:a is a semantic duplicate of u1:a but on a DIFFERENT source, so the
+        # per-source quota does not catch it -- the semantic stage must. u1:c is on
+        # the same source as u1:a: the quota skips it in the first pass but the fill
+        # pass admits it. The rejected u2:a is revisited in the fill pass and must be
+        # logged exactly once.
+        ranked = [
+            {"chunk_id": "u1:a", "source_url": "https://one/", "text": "one alpha",
+             "dense_embedding": [1.0, 0.0, 0.0]},
+            {"chunk_id": "u2:a", "source_url": "https://two/", "text": "two reworded",
+             "dense_embedding": [0.999, 0.01, 0.0]},
+            {"chunk_id": "u1:c", "source_url": "https://one/", "text": "one gamma distinct",
+             "dense_embedding": [0.0, 1.0, 0.0]},
+        ]
+        rejections: list[dict] = []
+        picked = select_chunks_with_quota_and_fill(
+            ranked,
+            final_limit=3,
+            max_per_source_url=1,
+            dedupe_jaccard_threshold=1.0,
+            semantic_dedupe_enabled=True,
+            semantic_dedupe_threshold=0.9,
+            rejections=rejections,
+        )
+        self.assertEqual([c["chunk_id"] for c in picked], ["u1:a", "u1:c"])
+        # The dropped chunk is revisited in the fill pass but logged only once.
+        self.assertEqual([r["chunk_id"] for r in rejections], ["u2:a"])
+
+    def test_selection_strips_nothing_but_reuses_embeddings(self) -> None:
+        # The selection service reads embeddings but does not mutate the input dicts.
+        chunk = dict(self.PARAPHRASE_A)
+        select_chunks_with_quota_and_fill(
+            [chunk],
+            final_limit=1,
+            max_per_source_url=0,
+            dedupe_jaccard_threshold=0.92,
+            semantic_dedupe_enabled=True,
+            semantic_dedupe_threshold=0.9,
+        )
+        self.assertIn("dense_embedding", chunk)
 
 
 if __name__ == "__main__":

--- a/tests/test_hybrid_embed_search_service.py
+++ b/tests/test_hybrid_embed_search_service.py
@@ -63,6 +63,23 @@ class HybridEmbedSearchServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("rrf_score", ranked[0])
         self.assertIn("rrf_similarity", ranked[0])
 
+    async def test_ranked_chunks_carry_dense_embedding_for_reuse(self) -> None:
+        # Semantic dedup downstream reuses these vectors instead of re-embedding.
+        chunks = [
+            {"chunk_id": "python", "text": "Python asyncio search uses async tasks."},
+            {"chunk_id": "bread", "text": "Bread recipes use flour and yeast."},
+        ]
+
+        ranked = await rank_chunks_hybrid(
+            "python async search",
+            chunks,
+            embedder=_fake_embedder,
+        )
+
+        by_id = {chunk["chunk_id"]: chunk for chunk in ranked}
+        self.assertEqual(by_id["python"]["dense_embedding"], [1.0, 0.0, 0.0])
+        self.assertEqual(by_id["bread"]["dense_embedding"], [0.0, 1.0, 0.0])
+
     async def test_rank_chunks_hybrid_applies_similarity_cutoff_and_top_k(self) -> None:
         chunks = [
             {"chunk_id": "python", "text": "Python asyncio search uses async tasks."},


### PR DESCRIPTION
## What
Adds an optional embedding-based semantic deduplication stage to research
chunk selection, layered after the existing lexical Jaccard filter. It removes
syndicated, paraphrased, or reworded chunks that share the same meaning but have
low literal token overlap, which the Jaccard filter cannot catch.

## How
- chunk_pool_selection_service: cosine-similarity dedup against already-accepted
  chunks in ranked order, so the highest-ranked member of a duplicate group is
  kept. Cooperates with per-source quotas and the fill pass, and records one
  rejection diagnostic per dropped chunk (chunk_id, reason, similarity,
  matched_chunk_id).
- hybrid_embed_search_service: attaches the dense document embedding already
  computed during ranking to each ranked chunk, so semantic dedup reuses it with
  no extra embedding calls. The embedding is dropped again after selection so it
  never bloats trace files or public payloads.
- config: adds chunk_semantic_dedupe_enabled (default true) and
  chunk_semantic_dedupe_threshold (default 0.92, conservative) with coercion and
  annotated config comments. SearchResult and existing shapes are unchanged.
- research pipeline: wires the new settings through selection.

## Design notes
Lexical Jaccard stays as a cheap first pass; semantic dedup ru
already-bounded oversampled pool, comparing each candidate to the running
selected output. A conservative default threshold avoids mergi
that happen to be phrased similarly, and the stage can be disabled entirely.

## Acceptance criteria
- Identifies semantically similar chunks despite low Jaccard o
- Retains the highest-ranked duplicate: done
- Works across varied source URLs including syndicated/paraphr
- Cooperates with per-source quotas and fill: done
- Reuses existing embeddings, no redundant computation: done
- Config in JSON settings: done
- Targeted tests for paraphrases, related-but-distinct chunks,
  variation, disabled state, embedding reuse: done
- README settings and design tradeoffs: done

## Testing
python -m unittest discover tests -> 293 passed (1 skipped).
Also drove the real research pipeline end-to-end with the ONNX
a paraphrase pair measured cosine 0.57 with Jaccard token overlap 0.18; with
semantic dedup enabled the lower-ranked paraphrase was dropped
both were kept.