### PR TITLE
Restore single-query backward compatibility for search

### DIFF
--- a/src/tinysearch/core.py
+++ b/src/tinysearch/core.py
@@ -61,21 +61,63 @@ async def _ensure_browser_bundle(config: Mapping[str, Any]) -> None:
     await asyncio.to_thread(ensure_chromium_sync)
 
 
-async def search(
-    items: Sequence[Mapping[str, Any]],
+def coerce_search_items(
+    items: Any = None,
     *,
+    query: str | None = None,
+    domains: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Normalize the accepted search input shapes into a list of ``{"query", "domains"}``.
+
+    The preferred shape is a batch ``items`` list. For backward compatibility a
+    single item mapping, a bare query string, or a top-level ``query`` (with an
+    optional ``domains`` list) are also accepted and wrapped into a one-item
+    list. This is the single place both server adapters and the Python API funnel
+    through, so all callers share identical rules.
+    """
+    if items is not None:
+        if isinstance(items, str):
+            raw_items: list[Any] = [{"query": items}]
+        elif isinstance(items, Mapping):
+            raw_items = [items]
+        elif isinstance(items, Sequence):
+            raw_items = list(items)
+        else:
+            raise ValueError("items must be a list of search items")
+    elif query is not None:
+        raw_items = [{"query": query, "domains": list(domains) if domains else []}]
+    else:
+        raise ValueError("provide items (a list of 1 to 5 search items) or a query")
+
+    if not 1 <= len(raw_items) <= 5:
+        raise ValueError("items must contain between 1 and 5 search items")
+
+    normalized: list[dict[str, Any]] = []
+    for item in raw_items:
+        if isinstance(item, str):
+            item = {"query": item}
+        if not isinstance(item, Mapping):
+            raise ValueError("each search item must be a query string or an object")
+        item_domains = item.get("domains", [])
+        if item_domains is None:
+            item_domains = []
+        normalized.append({"query": item.get("query"), "domains": list(item_domains)})
+    return normalized
+
+
+async def search(
+    items: Any = None,
+    *,
+    query: str | None = None,
+    domains: Sequence[str] | None = None,
     config: ConfigInput | None = None,
 ) -> dict[str, Any]:
-    """Return independent, backend-ordered discovery results for 1--5 items."""
-    if not 1 <= len(items) <= 5:
-        raise ValueError("items must contain between 1 and 5 search items")
-    normalized = []
-    for item in items:
-        query = item.get("query")
-        domains = item.get("domains", [])
-        if domains is None:
-            domains = []
-        normalized.append({"query": query, "domains": domains})
+    """Return independent, backend-ordered discovery results for 1 to 5 items.
+
+    Accepts the preferred batch ``items`` list and, for backward compatibility,
+    a single ``query`` (with optional ``domains``); see ``coerce_search_items``.
+    """
+    normalized = coerce_search_items(items, query=query, domains=domains)
     resolved_config = _resolve_config(config)
     started = time.monotonic()
     responses = await search_batch_with_metadata(

--- a/src/tinysearch/servers/fastapi_server.py
+++ b/src/tinysearch/servers/fastapi_server.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any, Literal
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
 from tinysearch import core
 from tinysearch.services.tinysearch_config_service import (
@@ -48,17 +49,32 @@ class ResearchRequest(BaseModel):
     output_format: Literal["prompt", "json"] = "prompt"
 
 
-class SearchRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    items: list["SearchItem"] = Field(..., min_length=1, max_length=5)
-
-
 class SearchItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str = Field(..., min_length=1)
     domains: list[str] = Field(default_factory=list)
+
+
+class SearchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[SearchItem] | None = Field(default=None, min_length=1, max_length=5)
+    # Deprecated single-query compatibility fields; prefer items. Kept so callers
+    # written against the pre-batch /search contract do not break on upgrade.
+    query: str | None = Field(default=None, min_length=1)
+    domains: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _coerce_single_query(self) -> "SearchRequest":
+        if self.items is None:
+            if self.query is None:
+                raise ValueError("provide items (1 to 5 search items) or a query")
+            self.items = [SearchItem(query=self.query, domains=self.domains or [])]
+        return self
+
+    def normalized_items(self) -> list[dict[str, Any]]:
+        return [item.model_dump() for item in self.items or []]
 
 
 @app.get("/health")
@@ -158,7 +174,13 @@ async def research_endpoint(request: ResearchRequest) -> dict[str, Any]:
 
 @app.post("/search")
 async def search_endpoint(request: SearchRequest) -> dict[str, Any]:
+    if request.query is not None:
+        print(
+            "[tinysearch] /search called with deprecated single-query shape; prefer items",
+            file=sys.stderr,
+            flush=True,
+        )
     return await core.search(
-        [item.model_dump() for item in request.items],
+        request.normalized_items(),
         config=load_tinysearch_config(),
     )

--- a/src/tinysearch/servers/mcp_server.py
+++ b/src/tinysearch/servers/mcp_server.py
@@ -249,14 +249,25 @@ async def get_current_datetime_tool() -> str:
 )
 async def search_tool(
     items: Annotated[
-        list[dict[str, Any]],
+        list[dict[str, Any]] | None,
         Field(description="One to five items, each with query and optional positive domains."),
-    ],
+    ] = None,
+    query: Annotated[
+        str | None,
+        Field(description="Deprecated single-query compatibility; prefer items."),
+    ] = None,
+    domains: Annotated[
+        list[str] | None,
+        Field(description="Deprecated; positive domains for the single-query compatibility form."),
+    ] = None,
 ) -> str:
     started = time.monotonic()
     config = load_tinysearch_config()
-    _log(f"search called items={len(items)}")
-    result = await core.search(items, config=config)
+    if items is None and query is not None:
+        _log("search called with deprecated single-query shape; prefer items")
+    item_count = len(items) if items is not None else (1 if query is not None else 0)
+    _log(f"search called items={item_count}")
+    result = await core.search(items, query=query, domains=domains, config=config)
     _log(
         f"search returning items={result['stats']['search_item_count']} "
         f"attempts={result['stats']['backend_attempt_count']} elapsed={time.monotonic() - started:.2f}s"

--- a/tests/test_fast_search.py
+++ b/tests/test_fast_search.py
@@ -87,8 +87,77 @@ class FastSearchTests(unittest.IsolatedAsyncioTestCase):
         ElementTree.fromstring(content[0].text)
         self.assertIn("<search_results>", content[0].text)
 
-    def test_mcp_search_exposes_only_items(self) -> None:
-        self.assertEqual(list(signature(_fn(search_tool)).parameters), ["items"])
+    def test_mcp_search_prefers_items_and_keeps_compat_params(self) -> None:
+        params = signature(_fn(search_tool)).parameters
+        # items stays the preferred, first parameter; query/domains are the
+        # backward-compatibility shim and default to None so batch calls are
+        # unaffected.
+        self.assertEqual(list(params), ["items", "query", "domains"])
+        self.assertIsNone(params["items"].default)
+        self.assertIsNone(params["query"].default)
+        self.assertIsNone(params["domains"].default)
+
+    async def test_mcp_search_accepts_deprecated_single_query(self) -> None:
+        with patch(
+            "tinysearch.servers.mcp_server.core.search", new=AsyncMock(return_value=_payload())
+        ) as search, patch(
+            "tinysearch.servers.mcp_server.load_tinysearch_config", return_value={}
+        ):
+            answer = await _fn(search_tool)(query="buses today")
+        ElementTree.fromstring(answer)
+        # The old single-query shape is forwarded as items=None + query=...; core
+        # normalizes it into a one-item batch.
+        self.assertIsNone(search.await_args.args[0])
+        self.assertEqual(search.await_args.kwargs["query"], "buses today")
+
+    async def test_fastapi_accepts_deprecated_single_query(self) -> None:
+        with patch(
+            "tinysearch.servers.fastapi_server.core.search",
+            new=AsyncMock(return_value=_payload()),
+        ) as search:
+            result = await search_endpoint(SearchRequest(query="buses today"))
+        self.assertEqual(result["items"][0]["status"], "ok")
+        self.assertEqual(search.await_args.args[0], [{"query": "buses today", "domains": []}])
+
+    def test_fastapi_search_request_requires_items_or_query(self) -> None:
+        with self.assertRaises(ValueError):
+            SearchRequest()
 
     def test_batch_payload_is_json_serializable(self) -> None:
         self.assertEqual(json.loads(json.dumps(_payload()))["operation"], "search_batch")
+
+
+class CoerceSearchItemsTests(unittest.TestCase):
+    def test_batch_items_pass_through_with_domains_default(self) -> None:
+        from tinysearch.core import coerce_search_items
+
+        self.assertEqual(
+            coerce_search_items([{"query": "a"}, {"query": "b", "domains": ["x.com"]}]),
+            [{"query": "a", "domains": []}, {"query": "b", "domains": ["x.com"]}],
+        )
+
+    def test_single_query_kwarg_wraps_into_one_item(self) -> None:
+        from tinysearch.core import coerce_search_items
+
+        self.assertEqual(
+            coerce_search_items(query="a", domains=["x.com"]),
+            [{"query": "a", "domains": ["x.com"]}],
+        )
+
+    def test_single_dict_and_bare_string_are_wrapped(self) -> None:
+        from tinysearch.core import coerce_search_items
+
+        self.assertEqual(coerce_search_items({"query": "a"}), [{"query": "a", "domains": []}])
+        self.assertEqual(coerce_search_items("a"), [{"query": "a", "domains": []}])
+
+    def test_requires_items_or_query(self) -> None:
+        from tinysearch.core import coerce_search_items
+
+        with self.assertRaisesRegex(ValueError, "provide items"):
+            coerce_search_items()
+
+    def test_rejects_more_than_five(self) -> None:
+        from tinysearch.core import coerce_search_items
+
+        with self.assertRaisesRegex(ValueError, "between 1 and 5"):
+            coerce_search_items([{"query": "q"}] * 6)


### PR DESCRIPTION
Fixes #61.

## Problem
0.6.2 changed the MCP `search` tool and `POST /search` to a required batch
`items` list (commit ac2a254). Clients, agents, and pipelines that still send
the previous single-query shape now fail with
`1 validation error for search_tool Arguments: items Field required`, which is
what @mrman486 hit after upgrading. Rolling back to 0.6.1 works because that
version still accepted the single-query shape.

## Fix
As discussed in the issue, this restores backward compatibility while keeping
the batch `items` interface as the preferred, documented contract.

- `core.search`: new `coerce_search_items`, the single place that normalizes
  every accepted shape (batch `items` list, a single item mapping, a bare query
  string, or a top-level `query` with optional `domains`) into a list of
  `{query, domains}`.
- MCP `search` tool: accepts optional `query`/`domains` alongside `items` and
  forwards them to `core.search`; logs a deprecation notice when the old shape
  is used. The tool instructions still document `items` only.
- `POST /search`: accepts an optional top-level `query` (and `domains`) and
  coerces it to a one-item batch; logs a deprecation notice.

The old shape is kept for a gradual deprecation and is intentionally not
advertised in the tool instructions or README.

## Tests
`python -m unittest discover tests` -> 304 passed (1 skipped, the opt-in live
search test). Added tests cover both shapes on the MCP tool and FastAPI, and
`coerce_search_items` directly. Also drove the FastMCP tool manager with the old
`{"query": "..."}` arguments to confirm the exact call from #61 now succeeds.